### PR TITLE
Fixed SQLite issues

### DIFF
--- a/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
+++ b/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
@@ -32,6 +32,9 @@ open class Connection(
                 if (PluginConfig.hasExposed())
                     Database.connect({ coreConnection })
                 else null
+        if (config.dbms == Dbms.SQLite) {
+            TransactionManager.manager.defaultIsolationLevel = java.sql.Connection.TRANSACTION_SERIALIZABLE
+        }
         coreConnection.autoCommit = false
     }
 

--- a/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
+++ b/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
@@ -107,7 +107,7 @@ open class Connection(
     override fun transaction(block: Connection.() -> Unit) {
         javaConnection.autoCommit = false
         if (PluginConfig.hasExposed()) {
-            TransactionManager.currentOrNew(DEFAULT_ISOLATION_LEVEL).let {
+            TransactionManager.currentOrNew(TransactionManager.manager.defaultIsolationLevel).let {
                 try {
                     block()
                     it.commit()
@@ -153,7 +153,7 @@ open class Connection(
         return if (PluginConfig.hasExposed()) {
             val tr = TransactionManager.currentOrNull()
             if (tr == null) {
-                val newTr = TransactionManager.currentOrNew(DEFAULT_ISOLATION_LEVEL)
+                val newTr = TransactionManager.currentOrNew(TransactionManager.manager.defaultIsolationLevel)
                 newTr.exec(sql)
                 newTr.close()
             } else {

--- a/src/main/kotlin/com/improve_future/harmonica/core/adapter/SqliteAdapter.kt
+++ b/src/main/kotlin/com/improve_future/harmonica/core/adapter/SqliteAdapter.kt
@@ -18,6 +18,7 @@ internal class SqliteAdapter(connection: ConnectionInterface) :
             "  " + buildColumnDeclarationForCreateTableSql(it)
         }
         sql += "\n);"
+        connection.execute(sql)
     }
 
     override fun createIndex(tableName: String, columnName: String, unique: Boolean, method: IndexMethod?) {


### PR DESCRIPTION
## What is this pull request for? Why do you create this pull request?
I was having issue on SQLite transaction and I found a bug on `SqliteAdapter` that table creation SQL was not executed.

## What is changed?
- Default transaction isolation level for SQLite connection should be `TRANSACTION_SERIALIZABLE`
Related: https://github.com/JetBrains/Exposed/wiki/FAQ#q-sqlite3-fails-with-the-error-transaction-attempt-0-failed-sqlite-supports-only-transaction_serializable-and-transaction_read_uncommitted
- Fixed bug on `SqliteAdapter.kt`