### PR TITLE
Fixed issue #76

### DIFF
--- a/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
+++ b/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
@@ -2,7 +2,6 @@ package com.improve_future.harmonica.core
 
 import com.improve_future.harmonica.config.PluginConfig
 import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.io.Closeable
 import java.sql.*
@@ -33,7 +32,7 @@ open class Connection(
                 if (PluginConfig.hasExposed())
                     Database.connect({ coreConnection })
                 else null
-        if (config.dbms == Dbms.SQLite) {
+        if (config.dbms == Dbms.SQLite && PluginConfig.hasExposed()) {
             TransactionManager.manager.defaultIsolationLevel =
                     java.sql.Connection.TRANSACTION_SERIALIZABLE
         }


### PR DESCRIPTION
## What is this pull request for? Why do you create this pull request?
Setting `TransactionManager` properties without checking  `hasExposed()` will cause `ClassNotFoundException` on non Exposed environment.
This PR is a fix for a side effect of PR #73.
## What is changed?
- Added `hasExposed()` check.

## Other comment
Related PR: #73 
