### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `.github/dependabot.yml` for the `gradle` and `github-actions` ecosystems, weekly schedule, ungrouped (per spec/ci.md). Can land independently of the toolchain upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for Gradle and GitHub Actions.
  * Configured separate limits for the number of automated update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->