### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Harmonica - Kotlin Database Migration Tool
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) [ ![Download](https://api.bintray.com/packages/kenjiohtsuka/m/Harmonica/images/download.svg) ](https://bintray.com/kenjiohtsuka/m/Harmonica/_latestVersion)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Release](https://jitpack.io/v/KenjiOhtsuka/harmonica.svg)](https://jitpack.io/#KenjiOhtsuka/harmonica)
 [![CircleCI](https://circleci.com/gh/KenjiOhtsuka/harmonica.svg?style=svg)](https://circleci.com/gh/KenjiOhtsuka/harmonica)
 [![Twitter Follow](https://img.shields.io/twitter/follow/_kjot.svg?style=social)](https://twitter.com/_kjot)
 


### PR DESCRIPTION
Fixes the badge row in the README (part of #165):

- License badge linked to GPL-3.0 while showing MIT → now links to opensource.org/licenses/MIT.
- Dead bintray download badge → JitPack release badge (bintray/jcenter are shut down).