### PR TITLE
Phase 2: drop unused dependencies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
-    testImplementation("commons-codec:commons-codec:1.15")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -24,24 +24,10 @@ dependencies {
     // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-compiler-embeddable
     implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
 
-    /* JDBC */
-    testImplementation("mysql:mysql-connector-java:5.1.44")
-    //testCompile ("mysql:mysql-connector-mxj:5.0.12")
-    testImplementation("org.postgresql:postgresql:9.4.1212.jre6")
-    //testCompile ("com.opentable.components:otj-pg-embedded:0.9.0")
-    testImplementation("org.xerial:sqlite-jdbc:3.21.0.1")
-    // testCompile("com.oracle:ojdbc6:12.1.0.1-atlassian-hosted")
-    testImplementation("com.microsoft.sqlserver:mssql-jdbc:6.2.1.jre7")
-
     /* Implementation */
     implementation("org.jetbrains.kotlin:kotlin-scripting-jsr223:$kotlinVersion")
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-reflect
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 
     implementation("org.reflections:reflections:0.9.11")
-
-    // Latest version of kotlinx-html
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")


### PR DESCRIPTION
Part of Phase 2 (dependency upgrades) in spec/plan.md.

Removes dependencies that are not referenced anywhere in the codebase:

- `core`: `commons-codec:1.15` (test scope, unused)
- `gradle-plugin`: `kotlin-reflect` (only stdlib `KClass` used), `kotlinx-html-jvm:0.7.3` (unused here; only the excluded `document` module used it), and the 4 JDBC test drivers (mysql 5.1.44, postgresql 9.4.1212.jre6, sqlite 3.21.0.1, mssql 6.2.1.jre7) — unused by any test; integration drivers move to the Phase 4 module.

Per AGENTS.md hygiene rule (no unused deps). `./gradlew build` green locally (66 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal build configuration by removing unused testing and runtime dependencies.
  * No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->