### PR TITLE
Phase 2: upgrade JUnit Jupiter 5.4.2 -> 6.1.2

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -17,8 +18,8 @@ dependencies {
     // Tests
     testImplementation("org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.2")
 }
 
 java {
@@ -34,4 +35,17 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+configurations {
+    testCompileClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,6 +37,12 @@ tasks.test {
     useJUnitPlatform()
 }
 
+// JUnit 6 requires Java 17+, but published bytecode must stay JVM 8
+// (jvmTarget = JVM_1_8 above). The Gradle metadata of JUnit 6 artifacts
+// declares org.gradle.jvm.version = 17, while these configurations carry
+// 8 from targetCompatibility, which would reject the dependency. Override
+// the attribute on the test classpaths only so resolution succeeds and
+// tests run on the installed JDK (25), which satisfies the 17+ baseline.
 configurations {
     testCompileClasspath {
         attributes {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -31,8 +32,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
 
     // Dependencies to be able to run tests within gradle
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.2")
 
     //implementation localGroovy()  // Groovy SDK
     compileOnly(gradleApi())
@@ -63,6 +64,19 @@ tasks {
     task<Jar>("javadocJar") {
         from(javadoc)
         archiveClassifier.set("javadoc")
+    }
+}
+
+configurations {
+    testCompileClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
     }
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -67,6 +67,12 @@ tasks {
     }
 }
 
+// JUnit 6 requires Java 17+, but the plugin's published bytecode must stay
+// JVM 8 (jvmTarget = 1.8). JUnit 6 artifacts declare org.gradle.jvm.version
+// = 17 in their metadata while these configurations carry 8 from
+// targetCompatibility, so resolution would reject them. Override the
+// attribute on the test classpaths only; tests run on the installed JDK
+// (25), which satisfies the 17+ baseline.
 configurations {
     testCompileClasspath {
         attributes {


### PR DESCRIPTION
Part of Phase 2 (dependency upgrades) in spec/plan.md. Decision from open-decision review: target JUnit **6** (6.1.2, current stable).

Both modules: `junit-jupiter-api` + `junit-jupiter-engine` 5.4.2 → `junit-jupiter` 6.1.2 aggregator + explicit `junit-platform-launcher:6.1.2`.

Two things JUnit 6 forced:

1. **Java 17 baseline**: JUnit 6 ships class files for JVM 17+, and its Gradle metadata declares `org.gradle.jvm.version = 17`. Our test configurations carry `org.gradle.jvm.version = 8` (from `targetCompatibility = 1.8`), so resolution rejected the artifacts. Fix: override `TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE` to 17 on `testCompileClasspath`/`testRuntimeClasspath` only. **Main (published) bytecode stays JVM 8** — `jvmTarget = 1.8` and the jvm8-bytecode CI check are untouched.
2. **kotlin-test-junit5:2.3.20** pins junit-jupiter-api 5.10.1 / junit-platform-launcher 1.10.1; Gradle conflict resolution bumps them to 6.1.2. Verified green: 66 tests run on JUnit 6.1.2, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the testing framework configuration to JUnit 6.1.2.
  * Configured test compilation and execution for JVM version 17.
  * Standardized test behavior across core and Gradle plugin modules.

* **Chores**
  * Maintained JVM 8 compatibility for published build outputs.
  * Aligned test settings and runtime configuration across supported modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->