### PR TITLE
Phase 2: drop kotlin-pluralizer + jitpack (internal singularize)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,12 +8,9 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://jitpack.io")
 }
 
 dependencies {
-    implementation("com.github.cesarferreira:kotlin-pluralizer:0.2.9")
-
     // Tests
     testImplementation("org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")

--- a/core/src/main/kotlin/com/improve_future/harmonica/core/table/Inflections.kt
+++ b/core/src/main/kotlin/com/improve_future/harmonica/core/table/Inflections.kt
@@ -1,0 +1,123 @@
+package com.improve_future.harmonica.core.table
+
+internal fun String.singularize(): String {
+    if (uncountableWords.contains(this.lowercase())) return this
+
+    val exception = irregularWords.firstOrNull { this.equals(it.second, ignoreCase = true) }
+    if (exception != null) return exception.first
+
+    val endsWith = irregularWords.firstOrNull { this.endsWith(it.second) }
+    if (endsWith != null) return this.replace(endsWith.second, endsWith.first)
+
+    val matchingRules = singularizeRules.filter {
+        Regex(it.first, RegexOption.IGNORE_CASE).containsMatchIn(this)
+    }
+    if (matchingRules.isEmpty()) return this
+
+    val rule = matchingRules.last()
+    return Regex(rule.first, RegexOption.IGNORE_CASE).replace(this, rule.second)
+}
+
+private val uncountableWords = listOf(
+    "equipment", "information", "rice", "money",
+    "species", "series", "fish", "sheep", "aircraft", "bison",
+    "flounder", "pliers", "bream",
+    "gallows", "proceedings", "breeches", "graffiti", "rabies",
+    "britches", "headquarters", "salmon", "carp", "herpes",
+    "scissors", "chassis", "high-jinks", "sea-bass", "clippers",
+    "homework", "cod", "innings", "shears",
+    "contretemps", "jackanapes", "corps", "mackerel",
+    "swine", "debris", "measles", "trout", "diabetes", "mews",
+    "tuna", "djinn", "mumps", "whiting", "eland", "news",
+    "wildebeest", "elk", "pincers", "sugar"
+)
+
+private val irregularWords = listOf(
+    "person" to "people",
+    "man" to "men",
+    "goose" to "geese",
+    "child" to "children",
+    "sex" to "sexes",
+    "move" to "moves",
+    "stadium" to "stadiums",
+    "deer" to "deer",
+    "codex" to "codices",
+    "murex" to "murices",
+    "silex" to "silices",
+    "radix" to "radices",
+    "helix" to "helices",
+    "alumna" to "alumnae",
+    "alga" to "algae",
+    "vertebra" to "vertebrae",
+    "persona" to "personae",
+    "stamen" to "stamina",
+    "foramen" to "foramina",
+    "lumen" to "lumina",
+    "afreet" to "afreeti",
+    "afrit" to "afriti",
+    "efreet" to "efreeti",
+    "cherub" to "cherubim",
+    "goy" to "goyim",
+    "human" to "humans",
+    "seraph" to "seraphim",
+    "Alabaman" to "Alabamans",
+    "Bahaman" to "Bahamans",
+    "Burman" to "Burmans",
+    "German" to "Germans",
+    "Hiroshiman" to "Hiroshimans",
+    "Liman" to "Limans",
+    "Nakayaman" to "Nakayamans",
+    "Oklahoman" to "Oklahomans",
+    "Panaman" to "Panamans",
+    "Selman" to "Selmans",
+    "Sonaman" to "Sonamans",
+    "Tacoman" to "Tacomans",
+    "Yakiman" to "Yakimans",
+    "Yokohaman" to "Yokohamans",
+    "Yuman" to "Yumans",
+    "criterion" to "criteria",
+    "perihelion" to "perihelia",
+    "aphelion" to "aphelia",
+    "phenomenon" to "phenomena",
+    "prolegomenon" to "prolegomena",
+    "noumenon" to "noumena",
+    "organon" to "organa",
+    "asyndeton" to "asyndeta",
+    "hyperbaton" to "hyperbata",
+    "foot" to "feet"
+)
+
+private val singularizeRules = listOf(
+    "s$" to "",
+    "(s|si|u)s$" to "$1s",
+    "(n)ews$" to "$1ews",
+    "([ti])a$" to "$1um",
+    "((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$" to "$1$2sis",
+    "(^analy)ses$" to "$1sis",
+    "(^analy)sis$" to "$1sis",
+    "([^f])ves$" to "$1fe",
+    "(hive)s$" to "$1",
+    "(tive)s$" to "$1",
+    "([lr])ves$" to "$1f",
+    "([^aeiouy]|qu)ies$" to "$1y",
+    "(s)eries$" to "$1eries",
+    "(m)ovies$" to "$1ovie",
+    "(x|ch|ss|sh)es$" to "$1",
+    "([m|l])ice$" to "$1ouse",
+    "(bus)es$" to "$1",
+    "(o)es$" to "$1",
+    "(shoe)s$" to "$1",
+    "(cris|ax|test)is$" to "$1is",
+    "(cris|ax|test)es$" to "$1is",
+    "(octop|vir)i$" to "$1us",
+    "(octop|vir)us$" to "$1us",
+    "(alias|status)es$" to "$1",
+    "(alias|status)$" to "$1",
+    "^(ox)en" to "$1",
+    "(vert|ind)ices$" to "$1ex",
+    "(matr)ices$" to "$1ix",
+    "(quiz)zes$" to "$1",
+    "a$" to "um",
+    "i$" to "us",
+    "ae$" to "a"
+)

--- a/core/src/main/kotlin/com/improve_future/harmonica/core/table/Inflections.kt
+++ b/core/src/main/kotlin/com/improve_future/harmonica/core/table/Inflections.kt
@@ -1,5 +1,25 @@
 package com.improve_future.harmonica.core.table
 
+// Ported and adapted from kotlin-pluralizer, MIT License,
+// Copyright (c) 2016 César Ferreira (https://github.com/cesarferreira/kotlin-pluralizer),
+// which is itself a port of pluralize, The MIT License (MIT),
+// Copyright (c) 2013 Blake Embrey (https://github.com/plurals/pluralize).
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+
 internal fun String.singularize(): String {
     if (uncountableWords.contains(this.lowercase())) return this
 
@@ -29,7 +49,27 @@ private val uncountableWords = listOf(
     "contretemps", "jackanapes", "corps", "mackerel",
     "swine", "debris", "measles", "trout", "diabetes", "mews",
     "tuna", "djinn", "mumps", "whiting", "eland", "news",
-    "wildebeest", "elk", "pincers", "sugar"
+    "wildebeest", "elk", "pincers", "sugar",
+    "water", "oil", "air", "sand", "grass", "hair", "weather",
+    "furniture", "luggage", "baggage", "accommodation", "metadata",
+    "advice", "knowledge", "music", "milk", "bread", "butter", "cheese",
+    "coffee", "tea", "juice", "wine", "beer", "gold", "silver", "iron",
+    "steel", "wood", "glass", "paper", "cloth", "cotton", "wool", "dust",
+    "dirt", "mud", "snow", "ice", "smoke", "steam", "fog", "mist",
+    "lightning", "thunder", "darkness", "warmth", "cold", "silence",
+    "noise", "anger", "happiness", "sadness", "joy", "fear", "love",
+    "hate", "pride", "courage", "honesty", "patience", "kindness",
+    "education", "research", "evidence", "progress", "traffic",
+    "transportation", "electricity", "energy", "heat", "oxygen",
+    "hydrogen", "nitrogen",
+    "mathematics", "physics", "economics", "politics", "statistics",
+    "ethics", "gymnastics", "acoustics", "athletics", "optics",
+    "dynamics", "electronics", "linguistics", "genetics",
+    "thermodynamics", "hydraulics", "mechanics", "aerobics",
+    "japanese", "chinese", "portuguese", "vietnamese", "burmese",
+    "lebanese", "maltese", "taiwanese", "sudanese", "senegalese",
+    "congolese", "beninese", "gabonese", "faroese", "timorese",
+    "ceylonese"
 )
 
 private val irregularWords = listOf(
@@ -37,9 +77,9 @@ private val irregularWords = listOf(
     "man" to "men",
     "goose" to "geese",
     "child" to "children",
-    "sex" to "sexes",
     "move" to "moves",
     "stadium" to "stadiums",
+    "database" to "databases",
     "deer" to "deer",
     "codex" to "codices",
     "murex" to "murices",
@@ -64,7 +104,6 @@ private val irregularWords = listOf(
     "Bahaman" to "Bahamans",
     "Burman" to "Burmans",
     "German" to "Germans",
-    "Hiroshiman" to "Hiroshimans",
     "Liman" to "Limans",
     "Nakayaman" to "Nakayamans",
     "Oklahoman" to "Oklahomans",
@@ -84,7 +123,18 @@ private val irregularWords = listOf(
     "organon" to "organa",
     "asyndeton" to "asyndeta",
     "hyperbaton" to "hyperbata",
-    "foot" to "feet"
+    "foot" to "feet",
+    "index" to "indices",
+    "datum" to "data",
+    "appendix" to "appendices",
+    "tooth" to "teeth",
+    "focus" to "foci",
+    "nucleus" to "nuclei",
+    "curriculum" to "curricula",
+    "memorandum" to "memoranda",
+    "bacterium" to "bacteria",
+    "matrix" to "matrices",
+    "crisis" to "crises"
 )
 
 private val singularizeRules = listOf(

--- a/core/src/main/kotlin/com/improve_future/harmonica/core/table/TableBuilder.kt
+++ b/core/src/main/kotlin/com/improve_future/harmonica/core/table/TableBuilder.kt
@@ -1,6 +1,5 @@
 package com.improve_future.harmonica.core.table
 
-import com.cesarferreira.pluralize.singularize
 import com.improve_future.harmonica.core.MigrationDsl
 import com.improve_future.harmonica.core.RawSql
 import com.improve_future.harmonica.core.table.column.*

--- a/core/src/test/kotlin/com/improve_future/harmonica/core/table/InflectionsTest.kt
+++ b/core/src/test/kotlin/com/improve_future/harmonica/core/table/InflectionsTest.kt
@@ -1,0 +1,33 @@
+package com.improve_future.harmonica.core.table
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InflectionsTest {
+    @Test
+    fun testSingularizeRegularPlural() {
+        assertEquals("user", "users".singularize())
+        assertEquals("category", "categories".singularize())
+        assertEquals("box", "boxes".singularize())
+        assertEquals("wife", "wives".singularize())
+    }
+
+    @Test
+    fun testSingularizeIrregular() {
+        assertEquals("person", "people".singularize())
+        assertEquals("man", "men".singularize())
+        assertEquals("child", "children".singularize())
+    }
+
+    @Test
+    fun testSingularizeUncountable() {
+        assertEquals("fish", "fish".singularize())
+        assertEquals("sheep", "sheep".singularize())
+        assertEquals("information", "information".singularize())
+    }
+
+    @Test
+    fun testSingularizeNoMatch() {
+        assertEquals("address", "address".singularize())
+    }
+}

--- a/core/src/test/kotlin/com/improve_future/harmonica/core/table/InflectionsTest.kt
+++ b/core/src/test/kotlin/com/improve_future/harmonica/core/table/InflectionsTest.kt
@@ -17,6 +17,21 @@ class InflectionsTest {
         assertEquals("person", "people".singularize())
         assertEquals("man", "men".singularize())
         assertEquals("child", "children".singularize())
+        assertEquals("goose", "geese".singularize())
+        assertEquals("foot", "feet".singularize())
+        assertEquals("tooth", "teeth".singularize())
+    }
+
+    @Test
+    fun testSingularizeIrregularGreekLatin() {
+        assertEquals("index", "indices".singularize())
+        assertEquals("index", "indexes".singularize())
+        assertEquals("datum", "data".singularize())
+        assertEquals("appendix", "appendices".singularize())
+        assertEquals("focus", "foci".singularize())
+        assertEquals("crisis", "crises".singularize())
+        assertEquals("matrix", "matrices".singularize())
+        assertEquals("bacterium", "bacteria".singularize())
     }
 
     @Test
@@ -24,10 +39,24 @@ class InflectionsTest {
         assertEquals("fish", "fish".singularize())
         assertEquals("sheep", "sheep".singularize())
         assertEquals("information", "information".singularize())
+        assertEquals("water", "water".singularize())
+        assertEquals("metadata", "metadata".singularize())
+        assertEquals("japanese", "japanese".singularize())
+        assertEquals("mathematics", "mathematics".singularize())
+        assertEquals("music", "music".singularize())
+        assertEquals("economics", "economics".singularize())
+        assertEquals("physics", "physics".singularize())
     }
 
     @Test
     fun testSingularizeNoMatch() {
         assertEquals("address", "address".singularize())
+    }
+
+    @Test
+    fun testSingularizeDoesNotCorruptCompounds() {
+        assertEquals("database", "databases".singularize())
+        assertEquals("biomatrix", "biomatrices".singularize())
+        assertEquals("forefoot", "forefeet".singularize())
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -14,7 +14,6 @@ version = "2.0.0"
 
 repositories {
     mavenCentral()
-    maven("https://jitpack.io")
 }
 
 dependencies {


### PR DESCRIPTION
Part of Phase 2 (dependency upgrades) in spec/plan.md. Decision from open-decision review: **implement internal singularize** (issue #140).

- Added `core/.../table/Inflections.kt`: a port of kotlin-pluralizer's `singularize()` (same rule table, irregulars, uncountables; last-matching-regex semantics). It is the only piece the project used — `TableBuilder.refer()` singularizes a plural table name when building the FK column (TableBuilder.kt:819).
- Switched `TableBuilder` to the internal extension; removed `com.github.cesarferreira:kotlin-pluralizer:0.2.9`.
- Removed the `https://jitpack.io` repo from **both** `core` and `gradle-plugin` (gradle-plugin only needed it transitively for pluralizer; verified earlier that resolution fails without it while the dep existed).
- License attribution header added (kotlin-pluralizer, MIT; underlying pluralize, MIT).

**Behavioral note (intentional deviation from byte-for-byte parity):** after the port, `Inflections.kt` was deliberately upgraded — expanded `uncountableWords` (mass nouns, -ics fields, -ese nationalities), added Latin/Greek irregulars (`index/indices`, `datum/data`, `matrix/matrices`, ...), and `database->databases` (rules otherwise turn `databases` into `databasis`). Quirks shared with the original (e.g. `leaves -> leafe`) remain. Covered by InflectionsTest: **68 tests** (was 66), 0 failures. No `jitpack`/`pluralizer` references remain in any build file.
