### PR TITLE
Phase 2: narrow loadClass catch to recoverable exceptions in scanner

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/task/JarmonicaTaskMain.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/task/JarmonicaTaskMain.kt
@@ -107,7 +107,9 @@ abstract class JarmonicaTaskMain {
     private fun loadClass(className: String): Class<*>? {
         return try {
             Class.forName(className, false, classLoader)
-        } catch (e: Throwable) {
+        } catch (e: ClassNotFoundException) {
+            null
+        } catch (e: LinkageError) {
             null
         }
     }


### PR DESCRIPTION
Follow-up to #185 (CodeRabbit feedback, comment moved here since the file is now on develop).

`loadClass` previously swallowed all `Throwable` (incl. `OutOfMemoryError`, `StackOverflowError`, programming errors). Narrow to the two failure modes the scanner actually expects when a classpath class cannot be loaded: `ClassNotFoundException` and `LinkageError` (covers `NoClassDefFoundError`, `UnsupportedClassVersionError`). Both still map to null (class skipped), preserving behavior; catastrophic errors now propagate.