### PR TITLE
Add spec planning docs, plan-review skill, and opencode agent config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - 'spec/**'
       - 'docs/**'
       - 'document/**'
+      - 'AGENTS.md'
+      - '.opencode/**'
   push:
     branches:
       - develop
@@ -16,6 +18,8 @@ on:
       - 'spec/**'
       - 'docs/**'
       - 'document/**'
+      - 'AGENTS.md'
+      - '.opencode/**'
 
 permissions:
   contents: read

--- a/.github/workflows/jvm8-bytecode.yml
+++ b/.github/workflows/jvm8-bytecode.yml
@@ -7,6 +7,8 @@ on:
       - 'spec/**'
       - 'docs/**'
       - 'document/**'
+      - 'AGENTS.md'
+      - '.opencode/**'
   push:
     branches:
       - develop
@@ -16,6 +18,8 @@ on:
       - 'spec/**'
       - 'docs/**'
       - 'document/**'
+      - 'AGENTS.md'
+      - '.opencode/**'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fabric.properties
 
 ### Custom
 .DS_Store
+
+# opencode local dependencies
+.opencode/node_modules/

--- a/.opencode/agents/build-review.md
+++ b/.opencode/agents/build-review.md
@@ -23,11 +23,12 @@ Verify against `spec/tech-notes.md` (dependency upgrade table) and
    dev machine (Java 25) and support JVM 8 bytecode. Kotlin must stay in the
    2.3.x line unless the constraint has changed.
 5. **CI**: any workflow change must match `spec/ci.md` (§3 shapes: PR-driven,
-   checkout@v4 + gradle/actions/setup-gradle@v4, JDK 25, jvm8-bytecode
-   major-version 52 assertion, concurrency, least-privilege permissions,
-   Dependabot weekly/ungrouped).
-6. **Module split reality**: do not assume `core`, `gradle-plugin`, `document`
-   build correctly — Phase 0 is the first real verification. Flag packaging /
+   checkout@v7 + gradle/actions/setup-gradle@v6 + setup-java (JDK 25),
+   jvm8-bytecode major-version 52 assertion, concurrency, least-privilege
+   permissions, Dependabot weekly/ungrouped).
+6. **Module split reality**: on pre-Phase 0 branches the split build was
+   unverified; since Phase 0 (PR #183) `core` and `gradle-plugin` build and are
+   covered by CI (`document/` is excluded from the build). Flag packaging /
    coordinates / plugin-ID inconsistencies (see `spec/plan.md` Phase 0).
 
 Report findings numbered and grouped by severity (BLOCKER / WARNING / NOTE),

--- a/.opencode/agents/build-review.md
+++ b/.opencode/agents/build-review.md
@@ -1,0 +1,35 @@
+---
+description: Reviews build-system changes (Gradle, Kotlin, dependencies, CI) against spec/tech-notes.md and spec/ci.md. Run before the Phase 0 PR and before any dependency or build-file change.
+mode: subagent
+permission:
+  edit: deny
+---
+
+You are a strict reviewer of build-system work in the Harmonica repo.
+
+Verify against `spec/tech-notes.md` (dependency upgrade table) and
+`spec/ci.md` (workflow design). Specifically:
+
+1. **JVM 8 target**: `jvmTarget = 1.8` must never change. Flag any edit that
+   removes or alters it.
+2. **Dependency table compliance**: every added/removed/changed dependency must
+   match the upgrade table or be justified. Flag new dependencies that are
+   unused, and removed ones that still have call sites (grep the codebase —
+   e.g. `commons-codec`, `kotlin-reflect`, `kotlinx-html-jvm`,
+   `org.reflections`).
+3. **Repo hygiene**: no jcenter/bintray references; jitpack only in `core`
+   while `kotlin-pluralizer` still exists; no duplicate repositories.
+4. **Gradle/Kotlin compatibility**: proposed versions must actually run on the
+   dev machine (Java 25) and support JVM 8 bytecode. Kotlin must stay in the
+   2.3.x line unless the constraint has changed.
+5. **CI**: any workflow change must match `spec/ci.md` (§3 shapes: PR-driven,
+   checkout@v4 + gradle/actions/setup-gradle@v4, JDK 25, jvm8-bytecode
+   major-version 52 assertion, concurrency, least-privilege permissions,
+   Dependabot weekly/ungrouped).
+6. **Module split reality**: do not assume `core`, `gradle-plugin`, `document`
+   build correctly — Phase 0 is the first real verification. Flag packaging /
+   coordinates / plugin-ID inconsistencies (see `spec/plan.md` Phase 0).
+
+Report findings numbered and grouped by severity (BLOCKER / WARNING / NOTE),
+each with the file:line reference and the correction needed. Do not edit
+files.

--- a/.opencode/agents/build-review.md
+++ b/.opencode/agents/build-review.md
@@ -1,5 +1,5 @@
 ---
-description: Reviews build-system changes (Gradle, Kotlin, dependencies, CI) against spec/tech-notes.md and spec/ci.md. Run before the Phase 0 PR and before any dependency or build-file change.
+description: Reviews build-system changes (Gradle, Kotlin, dependencies, CI) against spec/tech-notes.md and spec/ci.md. Run before any dependency or build-file change.
 mode: subagent
 permission:
   edit: deny
@@ -17,8 +17,9 @@ Verify against `spec/tech-notes.md` (dependency upgrade table) and
    unused, and removed ones that still have call sites (grep the codebase —
    e.g. `commons-codec`, `kotlin-reflect`, `kotlinx-html-jvm`,
    `org.reflections`).
-3. **Repo hygiene**: no jcenter/bintray references; jitpack only in `core`
-   while `kotlin-pluralizer` still exists; no duplicate repositories.
+3. **Repo hygiene**: no jcenter/bintray/jitpack references in active build
+   files (only stale doc-string mentions remain in `document/`); no duplicate
+   repositories.
 4. **Gradle/Kotlin compatibility**: proposed versions must actually run on the
    dev machine (Java 25) and support JVM 8 bytecode. Kotlin must stay in the
    2.3.x line unless the constraint has changed.
@@ -26,10 +27,10 @@ Verify against `spec/tech-notes.md` (dependency upgrade table) and
    checkout@v7 + gradle/actions/setup-gradle@v6 + setup-java (JDK 25),
    jvm8-bytecode major-version 52 assertion, concurrency, least-privilege
    permissions, Dependabot weekly/ungrouped).
-6. **Module split reality**: on pre-Phase 0 branches the split build was
-   unverified; since Phase 0 (PR #183) `core` and `gradle-plugin` build and are
-   covered by CI (`document/` is excluded from the build). Flag packaging /
-   coordinates / plugin-ID inconsistencies (see `spec/plan.md` Phase 0).
+6. **Module split reality**: since Phase 0 (PR #183), `core` and `gradle-plugin`
+   build and are covered by CI; `document/` is a stale nested build excluded
+   from the root build. Flag packaging / coordinates / plugin-ID
+   inconsistencies (see `spec/plan.md` Phase 0).
 
 Report findings numbered and grouped by severity (BLOCKER / WARNING / NOTE),
 each with the file:line reference and the correction needed. Do not edit

--- a/.opencode/agents/exposed-review.md
+++ b/.opencode/agents/exposed-review.md
@@ -1,0 +1,34 @@
+---
+description: Reviews Exposed-optionality work (core connection changes, harmonica-exposed bridge) against spec/exposed-integration.md. Run before the Phase 3 PR or any change to core Connection.kt / PluginConfig.kt.
+mode: subagent
+permission:
+  edit: deny
+---
+
+You are a strict reviewer of Exposed-related work in the Harmonica repo.
+
+Verify against `spec/exposed-integration.md`:
+
+1. **core purity**: `core/` must contain zero Exposed imports and zero
+   Exposed knowledge. The only seam allowed is the JDBC connection
+   (`jdbcConnection` on `ConnectionInterface`, per §1).
+2. **Bridge location**: the Exposed bridge must be an extension on
+   `AbstractMigration` (or the migration receiver), NOT on the concrete
+   `Connection` — inside `up()` the receiver is `AbstractMigration` and its
+   `connection` is typed `ConnectionInterface` (see §2, Pitfall E).
+3. **Transaction ownership**: exactly one owner for commit/rollback/close. The
+   runner wraps `up()`/`down()` in `Connection.transaction`; the bridge must
+   not produce a nested Exposed commit/rollback. Options A/B must be resolved
+   before shipping any bridge snippet (§2.1).
+4. **Pitfalls**: no reconnect-invalidated cached `Database` (§2.2); document
+   the `setTransactionIsolation` no-op proxy, the single-threaded assumption,
+   and the `autoCommit` interplay; avoid the `com.improve_future.harmonica.core.Database`
+   name collision; the script classpath must expose the bridge to the JSR-223
+   engine (§2.2, Pitfall F).
+5. **Dead code**: the `hasExposed` constructor parameter, the dead ternary in
+   `Connection`, and `PluginConfig.hasExposed()` (if unused) must be removed,
+   not left as no-ops.
+
+Report findings numbered and grouped by severity (BLOCKER / WARNING / NOTE),
+each with the file:line reference and the correction needed. Do not edit
+files.

--- a/.opencode/agents/spec-review.md
+++ b/.opencode/agents/spec-review.md
@@ -12,8 +12,10 @@ spec docs. Specifically:
 
 1. **Plan adherence**: the work must map to a named phase or an explicit
    pre-toolchain PR. Any drift must be flagged.
-2. **Factual accuracy**: verify claims against the actual repo. Confirm issue
-   numbers are open (not closed), dependency versions match `build.gradle.kts`
+2. **Factual accuracy**: verify claims against the actual repo. Validate each
+   referenced issue's GitHub state against the document's claim: **active**
+   issues must be open, while **resolved** issues may be closed or still
+   awaiting user closure. Confirm dependency versions match `build.gradle.kts`
    files, file paths and line references exist, and counts (e.g. license
    headers, open issues) are right. Do NOT trust prior claims — re-check with
    `git log`, `gh issue`, Grep/Glob, and file reads.

--- a/.opencode/agents/spec-review.md
+++ b/.opencode/agents/spec-review.md
@@ -26,7 +26,7 @@ spec docs. Specifically:
 4. **Open decisions**: anything gated on `spec/plan.md` §6 "Open decisions"
    must be labeled as such, not asserted as decided.
 5. **Small-PR rule**: any proposed work that would be a large PR must be
-   justified (only the Phase 0 toolchain PR is exempt).
+   justified — split it into smaller PRs unless there is a reason not to.
 
 Report findings as a numbered list grouped by severity (BLOCKER / WARNING /
 NOTE), each with the file:line reference and the correction needed. Do not

--- a/.opencode/agents/spec-review.md
+++ b/.opencode/agents/spec-review.md
@@ -1,0 +1,31 @@
+---
+description: Reviews spec/ planning docs and PRs for consistency, accuracy, and adherence to the restart plan. Run before opening PRs that touch spec/ or propose new work.
+mode: subagent
+permission:
+  edit: deny
+---
+
+You are a strict reviewer of the Harmonica restart planning documents.
+
+Check that a change or PR is consistent with `spec/plan.md` and the other
+spec docs. Specifically:
+
+1. **Plan adherence**: the work must map to a named phase or an explicit
+   pre-toolchain PR. Any drift must be flagged.
+2. **Factual accuracy**: verify claims against the actual repo. Confirm issue
+   numbers are open (not closed), dependency versions match `build.gradle.kts`
+   files, file paths and line references exist, and counts (e.g. license
+   headers, open issues) are right. Do NOT trust prior claims — re-check with
+   `git log`, `gh issue`, Grep/Glob, and file reads.
+3. **Cross-doc consistency**: `plan.md`, `issues-triage.md`, `testing.md`,
+   `ci.md`, `tech-notes.md`, and `exposed-integration.md` must not contradict
+   each other (e.g. an issue listed as urgent in one place and closed in
+   another, or a dependency listed in two tables with different targets).
+4. **Open decisions**: anything gated on `spec/plan.md` §6 "Open decisions"
+   must be labeled as such, not asserted as decided.
+5. **Small-PR rule**: any proposed work that would be a large PR must be
+   justified (only the Phase 0 toolchain PR is exempt).
+
+Report findings as a numbered list grouped by severity (BLOCKER / WARNING /
+NOTE), each with the file:line reference and the correction needed. Do not
+edit files.

--- a/.opencode/commands/review-specs.md
+++ b/.opencode/commands/review-specs.md
@@ -1,0 +1,12 @@
+---
+description: Reconcile the spec/ planning docs (plan.md, tech-notes.md, issues-triage.md) with the actual repo and apply updates. Wrapper for the plan-review skill.
+agent: general
+---
+
+Run the `plan-review` skill: gather ground truth (`git log` on `origin/develop`,
+`gh issue`/`gh pr` lists, dependency versions from the build files,
+`./gradlew test` for the authoritative test count), diff `spec/plan.md`,
+`spec/tech-notes.md`, and `spec/issues-triage.md` against it, apply the
+updates to `spec/` (never commit), then delegate a final verification pass to
+the `spec-review` agent. Report what changed and which GitHub issues the user
+should close.

--- a/.opencode/skills/harmonica-dev/SKILL.md
+++ b/.opencode/skills/harmonica-dev/SKILL.md
@@ -32,7 +32,8 @@ change.
 - `core` must never import Exposed.
 - `document/` is a stale nested build — excluded from the root build since
   Phase 0; do not expect it to compile in `./gradlew build`.
-- When editing opencode config, load the `customize-opencode` skill.
+- When editing any file under `.opencode/**`, load the `customize-opencode`
+  skill and consult the OpenCode configuration schema.
 
 ## Workflow
 

--- a/.opencode/skills/harmonica-dev/SKILL.md
+++ b/.opencode/skills/harmonica-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harmonica-dev
-description: Use when working on the Harmonica Kotlin DB migration tool — planning, phase work, PRs, or anything touching this repo. Encodes the restart workflow: read spec/ before proposing work, small PRs per issue, toolchain constraints (JVM 8 target, Gradle 6.5 wrapper unusable on the Java 25 dev machine, Phase 0 prerequisite), and conventions (no comments, no unused deps, core stays Exposed-free).
+description: Use when working on the Harmonica Kotlin DB migration tool — planning, phase work, PRs, or anything touching this repo. Encodes the restart workflow: read spec/ before proposing work, small PRs per issue, toolchain constraints (JVM 8 target, Gradle 9.6.1 + Kotlin 2.3.20 on the Java 25 dev machine), and conventions (no comments, no unused deps, core stays Exposed-free).
 ---
 
 # Harmonica Development
@@ -20,12 +20,9 @@ change.
 ## Hard constraints
 
 - JVM 8 bytecode target (`jvmTarget = 1.8`) — never bump.
-- `./gradlew build` currently does NOT work on the dev machine (Gradle 6.5
-  wrapper + Kotlin 1.4.20 vs OpenJDK 25). Build verification is impossible
-  until Phase 0. Do not treat red builds as bugs to fix piecemeal.
-- One change per PR against `develop`, except the Phase 0 toolchain PR which
-  must move together (Gradle 9 + Kotlin 2.3 + buildscript rewrite + source
-  modernization + CI rewrite).
+- `./gradlew build` works on this machine (Gradle 9.6.1 + Kotlin 2.3.20 on
+  OpenJDK 25). A red build is a real bug — fix it, don't defer.
+- One change per PR against `develop`.
 - Never commit unless explicitly asked.
 
 ## Conventions
@@ -33,8 +30,8 @@ change.
 - No comments in code unless asked.
 - No new dependencies unless actually used (repo has a history of unused deps).
 - `core` must never import Exposed.
-- `document/` is a stale nested build — assume it is not part of any green
-  build until Phase 0 decides its fate.
+- `document/` is a stale nested build — excluded from the root build since
+  Phase 0; do not expect it to compile in `./gradlew build`.
 - When editing opencode config, load the `customize-opencode` skill.
 
 ## Workflow

--- a/.opencode/skills/harmonica-dev/SKILL.md
+++ b/.opencode/skills/harmonica-dev/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: harmonica-dev
+description: Use when working on the Harmonica Kotlin DB migration tool — planning, phase work, PRs, or anything touching this repo. Encodes the restart workflow: read spec/ before proposing work, small PRs per issue, toolchain constraints (JVM 8 target, Gradle 6.5 wrapper unusable on the Java 25 dev machine, Phase 0 prerequisite), and conventions (no comments, no unused deps, core stays Exposed-free).
+---
+
+# Harmonica Development
+
+Work on this repository happens in phases tracked in `spec/plan.md`. The
+`spec/` directory is the source of truth; keep it in sync when decisions
+change.
+
+## Before proposing work
+
+1. Read `spec/plan.md` (master plan + open decisions + risk register).
+2. Read the phase-specific spec that applies: `spec/ci.md`, `spec/testing.md`,
+   `spec/exposed-integration.md`, `spec/issues-triage.md`, `spec/tech-notes.md`.
+3. Check `spec/plan.md` §6 "Open decisions" — if the work depends on an
+   unresolved decision, flag it and ask before proceeding.
+
+## Hard constraints
+
+- JVM 8 bytecode target (`jvmTarget = 1.8`) — never bump.
+- `./gradlew build` currently does NOT work on the dev machine (Gradle 6.5
+  wrapper + Kotlin 1.4.20 vs OpenJDK 25). Build verification is impossible
+  until Phase 0. Do not treat red builds as bugs to fix piecemeal.
+- One change per PR against `develop`, except the Phase 0 toolchain PR which
+  must move together (Gradle 9 + Kotlin 2.3 + buildscript rewrite + source
+  modernization + CI rewrite).
+- Never commit unless explicitly asked.
+
+## Conventions
+
+- No comments in code unless asked.
+- No new dependencies unless actually used (repo has a history of unused deps).
+- `core` must never import Exposed.
+- `document/` is a stale nested build — assume it is not part of any green
+  build until Phase 0 decides its fate.
+- When editing opencode config, load the `customize-opencode` skill.
+
+## Workflow
+
+- Cut a phase/feature branch from `develop`, do the work, open a small PR.
+- After finishing a phase, update the relevant `spec/` doc (plan phase status,
+  DoD, open decisions) as part of the same PR.
+- After a phase PR or milestone merges, run the `plan-review` skill to
+  reconcile `spec/plan.md`, `spec/tech-notes.md`, and `spec/issues-triage.md`
+  with reality (git log, issues/PRs, versions, test counts).
+- Use the review subagents (`spec-review`, `build-review`, `exposed-review`)
+  to validate spec-adjacent work before opening a PR.
+
+## Current phase status
+
+See `spec/plan.md` — phase status is reconciled by the `plan-review` skill
+after each merge, so don't hard-code the current phase here.

--- a/.opencode/skills/plan-review/SKILL.md
+++ b/.opencode/skills/plan-review/SKILL.md
@@ -59,7 +59,8 @@ Cross-check the three docs against each other — no contradictions.
 - One logical change per edit; preserve the existing style and table format.
 - Mark resolved issues as resolved **in the docs** with the PR reference, but
   do not close the GitHub issues — that is a separate user decision.
-- Update the "Snapshot ... 2026-08-01" date and count in issues-triage.md.
+- Update the "Snapshot ... <date>" header in issues-triage.md to the **actual
+  review date** and the current open-issue count.
 
 ### 4. Verify
 

--- a/.opencode/skills/plan-review/SKILL.md
+++ b/.opencode/skills/plan-review/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: plan-review
+description: Use when reviewing the Harmonica restart plan against reality — after a phase PR or milestone merges, before proposing the next phase, or when asked "are the specs up to date" / "what should we do next". Reconciles spec/plan.md, spec/tech-notes.md, and spec/issues-triage.md with the actual repo (git log, GitHub issues/PRs, dependency versions, test counts), applies updates to spec/, then verifies with the spec-review agent.
+---
+
+# Plan Review
+
+The `spec/` planning docs are the source of truth and go stale every time a
+phase PR merges. This workflow reconciles them with reality: gather ground
+truth, diff the docs, apply updates, verify. **Edit spec/ only. Never commit.**
+
+## When to run
+
+- After any phase PR or milestone merge.
+- Before proposing the next phase of work.
+- When the user asks "are the specs up to date?" / "what should we do next?".
+
+## Scope
+
+Keep in sync: `spec/plan.md`, `spec/tech-notes.md`, `spec/issues-triage.md`.
+Do not touch `spec/ci.md`, `spec/testing.md`, `spec/exposed-integration.md`,
+or `spec/README.md` unless a finding specifically requires it.
+
+## Steps
+
+### 1. Gather ground truth
+
+Run these and record the results before touching any doc:
+
+- `git fetch origin` then `git log --oneline origin/develop -15` — recent merges.
+- `gh pr list --state open` and `gh pr list --state merged --limit 25` — PR states.
+- `gh issue list --state open` — note the exact open count.
+- Grep versions from the build: `gradle/wrapper/gradle-wrapper.properties`,
+  `gradle.properties`, root/`core`/`gradle-plugin` `build.gradle.kts`,
+  `settings.gradle.kts` (wrapper, kotlin, junit, plugin-publish, dokka, test deps).
+- `./gradlew test` (JDK 25, this machine) for the authoritative test count and
+  build health. Static `@Test` grep counts drift from the real JUnit count —
+  trust the Gradle output, not the source grep.
+
+### 2. Diff the docs against ground truth
+
+For each of the three docs, find every claim that disagrees with reality:
+
+- **plan.md**: phase status blocks (`implemented`/`merged`, PR numbers, dates,
+  test counts); the phase checklists; §6 resolved/open decisions; §3 branch
+  strategy notes.
+- **tech-notes.md**: dependency table rows still marked `pending`/`untouched`
+  that are now `DONE` (add the PR ref); self-contradictions between a table row
+  and a later note; test counts; repository/protocol notes.
+- **issues-triage.md**: the open-issue count in the header (re-snapshot);
+  issues resolved by the work (move them out of the active table, note the
+  closing PR); new issues created since the snapshot (add them); stale
+  cross-references.
+
+Cross-check the three docs against each other — no contradictions.
+
+### 3. Apply updates
+
+- One logical change per edit; preserve the existing style and table format.
+- Mark resolved issues as resolved **in the docs** with the PR reference, but
+  do not close the GitHub issues — that is a separate user decision.
+- Update the "Snapshot ... 2026-08-01" date and count in issues-triage.md.
+
+### 4. Verify
+
+- Delegate a final pass to the `spec-review` agent (read-only) against the
+  updated docs. Fix any BLOCKER/WARNING findings it reports.
+
+### 5. Report
+
+Summarize: what changed in each doc, the authoritative test count, and a list
+of GitHub issues the user should close (with the PR that resolves each). Leave
+the changes uncommitted for the user to review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+Guidance for AI agents working on the Harmonica codebase.
+
+## Project
+
+Harmonica is a Kotlin DB migration tool (core library + a Gradle plugin,
+historically bundled with the Exposed ORM). Development was paused for years
+and is being restarted. See `spec/plan.md` for the master plan.
+
+## Important constraints
+
+- **Target bytecode is JVM 8** (`jvmTarget = 1.8`). Never bump this.
+- The only JDK installed on the dev machine is **OpenJDK 25**.
+- The repo is on **Gradle wrapper 9.6.1** and **Kotlin 2.3.20** (Phase 0, merged
+  via PR #183). `./gradlew build` works on this machine.
+- **Small changes per PR** against `develop`.
+- **Never commit** unless explicitly asked. Stage only intended files.
+
+## Layout
+
+- `core/` — the migration library (JDBC, no Exposed dependency).
+- `gradle-plugin/` — Gradle plugin + JSR-223 script engine for `.kts`
+  migrations.
+- `document/` — nested standalone Gradle build (site generator), stale.
+- `spec/` — planning docs; the source of truth for the restart. Read them
+  before proposing work; update them when decisions change.
+- `.opencode/` — opencode config, review agents, and this project's skill.
+
+## Conventions
+
+- Follow existing code style; do not add comments unless asked.
+- Do not add dependencies that are not actually used (there is a history of
+  unused deps: `commons-codec`, `kotlin-reflect`, `kotlinx-html-jvm` in the
+  plugin, JDBC test drivers).
+- Keep `core` free of any Exposed import. See `spec/exposed-integration.md`.
+- When editing opencode config (`opencode.json`, `.opencode/**`), consult the
+  `customize-opencode` skill and the schema at https://opencode.ai/config.json.

--- a/spec/README.md
+++ b/spec/README.md
@@ -16,28 +16,33 @@ plan to restart and modernize the project.
 
 ## Current state (baseline, branch `develop`)
 
-> Baseline snapshot taken before Phase 0. Toolchain work implemented 2026-08-01
-> on `feature/toolchain` (Gradle 9.6.1, Kotlin 2.3.20, CI rewrite) and **merged
-> via PR #183** — update this list when the baseline advances.
+> Snapshot taken 2026-08-08, after Phase 0 (toolchain) and Phase 2 (dead-dep
+> removal). Update this list when the baseline advances.
 
-- Kotlin 1.4.20, Gradle wrapper 6.5, `jvmTarget = 1.8`
-- Gradle plugin-publish 0.9.10, Dokka 0.9.17
-- Publish target: jcenter/bintray (both dead) and OSSRH staging config
-- CI: CircleCI (`circleci/openjdk:8-jdk`) + GitHub Actions (bare `gradle test`)
-- Three modules: `core`, `gradle-plugin`, `document` (nested standalone build)
-- License header block at the top of **86** source files (79 `.kt`, 4 `.kts`, 3
-  `.properties`) + 1 extensionless `META-INF/services/...` registration file —
-  since stripped (PR #180)
-- `jcenter()`/bintray already removed from all build files (2024 work); README
-  badges fixed (#181); dead reference remains only in a `document` doc-string
-- No Exposed dependency in `core` anymore (reflection-based detection remains)
-- Tests for real DBMS live in a separate repository `harmonica_test`
-- **`develop` is 30 commits ahead of `master` but never fully tested** — it
-  contains an untested module split (`feature/split`) and jcenter-removal
-  build work. See the risk register in [`plan.md`](plan.md).
+- Kotlin **2.3.20**, Gradle wrapper **9.6.1**, `jvmTarget = 1.8` (class-file
+  major 52 asserted in CI)
+- Gradle plugin-publish **2.1.1**, Dokka **2.2.0** (Dokka bundles Jackson
+  2.15.3 at build time only — not shipped; see the Dependabot alerts)
+- Publish target: plugin-publish + OSSRH staging (jcenter/bintray removed)
+- CI: GitHub Actions only — `ci.yml` (PR/push, Temurin JDK 25,
+  `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
+  `actions/setup-java@5.6.0`), `jvm8-bytecode.yml` (major-52 assertion),
+  `dependency-submit.yml` (Dependabot). CircleCI removed.
+- Two active modules: `core`, `gradle-plugin` — **72 tests green** (68 core +
+  4 plugin); `document` (nested standalone build) is excluded from the build
+- License headers stripped from all source files (PR #180); README badges fixed
+  (PR #181)
+- No Exposed dependency in `core` (runtime reflection detection remains in
+  `gradle-plugin`; a real Exposed bridge is a **future Phase 3** design, see
+  [`exposed-integration.md`](exposed-integration.md))
+- Tests for real DBMS still live in the separate `harmonica_test` repository —
+  to be merged in Phase 4
+- **`develop` is 56 commits ahead of `master`** — Phase 4 (real-DB tests) must
+  pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 
 ## Machine environment (current)
 
 - OpenJDK 25.0.3 (only JDK installed)
 - No standalone `gradle`, no `docker`
-- Gradle wrapper 6.5 cannot run on Java 25 → toolchain upgrade is step 1
+- Toolchain upgrade done (Phase 0, PR #183): the Gradle 9.6.1 wrapper runs on
+  Java 25, so `./gradlew build` works locally.

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,43 @@
+# Harmonica Development Restart — Spec
+
+Harmonica development was paused several years ago. This directory holds the
+plan to restart and modernize the project.
+
+## Documents
+
+| File | Purpose |
+| --- | --- |
+| [`plan.md`](plan.md) | Master roadmap: goals, phases, milestones, and definition of done |
+| [`tech-notes.md`](tech-notes.md) | Toolchain & dependency research (JDK / Gradle / Kotlin compatibility findings) |
+| [`exposed-integration.md`](exposed-integration.md) | Design for making the Exposed ORM **optional** for users |
+| [`testing.md`](testing.md) | Test strategy: merging `harmonica_test`, local DB environments, CI |
+| [`issues-triage.md`](issues-triage.md) | Triage of all open GitHub issues by urgency and size |
+| [`ci.md`](ci.md) | GitHub Actions, CI workflows, and Dependabot design |
+
+## Current state (baseline, branch `develop`)
+
+> Baseline snapshot taken before Phase 0. Toolchain work implemented 2026-08-01
+> on `feature/toolchain` (Gradle 9.6.1, Kotlin 2.3.20, CI rewrite) and **merged
+> via PR #183** — update this list when the baseline advances.
+
+- Kotlin 1.4.20, Gradle wrapper 6.5, `jvmTarget = 1.8`
+- Gradle plugin-publish 0.9.10, Dokka 0.9.17
+- Publish target: jcenter/bintray (both dead) and OSSRH staging config
+- CI: CircleCI (`circleci/openjdk:8-jdk`) + GitHub Actions (bare `gradle test`)
+- Three modules: `core`, `gradle-plugin`, `document` (nested standalone build)
+- License header block at the top of **86** source files (79 `.kt`, 4 `.kts`, 3
+  `.properties`) + 1 extensionless `META-INF/services/...` registration file —
+  since stripped (PR #180)
+- `jcenter()`/bintray already removed from all build files (2024 work); README
+  badges fixed (#181); dead reference remains only in a `document` doc-string
+- No Exposed dependency in `core` anymore (reflection-based detection remains)
+- Tests for real DBMS live in a separate repository `harmonica_test`
+- **`develop` is 30 commits ahead of `master` but never fully tested** — it
+  contains an untested module split (`feature/split`) and jcenter-removal
+  build work. See the risk register in [`plan.md`](plan.md).
+
+## Machine environment (current)
+
+- OpenJDK 25.0.3 (only JDK installed)
+- No standalone `gradle`, no `docker`
+- Gradle wrapper 6.5 cannot run on Java 25 → toolchain upgrade is step 1

--- a/spec/ci.md
+++ b/spec/ci.md
@@ -1,0 +1,169 @@
+# CI, GitHub Actions & Dependabot
+
+Design for continuous integration, GitHub Actions workflows, and automated
+dependency updates. Feeds into **Phase 0** (CI rewrite, part of the toolchain
+PR), Phase 4 (DB integration tests) and Phase 6 (release publishing).
+
+## 1. Current state
+
+**Phase 0 implemented 2026-08-01 (merged via PR #183).** `.github/workflows/gradle.yml` (broken: bare
+`gradle`, `checkout@v2`, push-only) and `.circleci/config.yml` (broken:
+`circleci/openjdk:8-jdk`, bare `gradle`, checksum of a nonexistent file) are
+**deleted**. Replaced by:
+
+- `.github/workflows/ci.yml` — main build & unit tests (JDK 25, PR/push).
+- `.github/workflows/jvm8-bytecode.yml` — asserts JVM 8 bytecode.
+- `.github/workflows/dependency-submit.yml` — submits the dependency graph that
+  `ci.yml` uploads (least-privilege split, see §3.1).
+- `.github/dependabot.yml` — landed earlier as its own PR (#169).
+
+## 2. Constraints
+
+- Gradle 9.1+ is required to *run* on the JDKs we use (Gradle 9.x daemon needs
+  JDK 17+; this project runs on JDK 25).
+- Target library bytecode is **JVM 8** (`jvmTarget = 1.8`). We cannot run
+  Gradle 9 on a JDK 8 runtime to "prove" this — verification is done via the
+  javap class-version check (§3.2).
+- Small changes per PR → CI is PR-driven, fast, and cancels stale runs.
+- User is on the GitHub **Student Developer Pack** (free tier). Public repos
+  get unlimited Actions minutes; the student plan covers private repos too.
+  Dependabot is free on all plans. Conservation is still good practice.
+
+## 3. Workflows
+
+### 3.1 `ci.yml` — main build & unit tests
+
+As landed:
+
+- **Triggers**: `pull_request` (any) and `push` to `develop`/`master`.
+  `paths-ignore` for `README.md`, `spec/`, `docs/`, `document/` so docs-only
+  changes don't burn minutes.
+- **Permissions**: `contents: read` (least privilege) on every job — the build
+  job **no longer escalates to `contents: write`**. The dependency graph is
+  *generated and uploaded* here (`dependency-graph: generate-and-upload`) and
+  *submitted* by the separate `workflow_run` workflow `dependency-submit.yml`
+  (which alone carries `actions: read, contents: write`). This is the
+  documented GitHub/Gradle pattern for dependency submission; it also works for
+  PRs from forks.
+- **Concurrency**: group on `github.ref`, `cancel-in-progress: true`.
+- **Steps**:
+  - `actions/checkout@v7` with `persist-credentials: false` (no step needs Git
+    authentication after checkout; Gradle doesn't use the persisted credential).
+  - `actions/setup-java@v4` with Temurin **JDK 25** — `setup-gradle` does **not**
+    install a JDK and ignores `distribution`/`java-version` inputs (only
+    `actions/setup-java` selects the JDK).
+  - `gradle/actions/setup-gradle@v4` with wrapper validation, build cache, and
+    `dependency-graph: generate-and-upload` (+
+    `dependency-graph-continue-on-failure: true`) so Dependabot PRs resolve
+    against an up-to-date dependency graph.
+  - `./gradlew build --no-daemon` (unit tests only by default; DB-gated tests
+    excluded — see `spec/testing.md`).
+- **Matrix (later, Phase 4)**: a `db-integration` job with `postgres:16` /
+  `mysql:8` service containers running the gated integration suite.
+
+### 3.2 `jvm8-bytecode.yml` — prove JVM 8 target without JDK 8
+
+Since Gradle 9 cannot run on JDK 8:
+
+- After `./gradlew build`, runs `javap -verbose` on **every `.class` file** in
+  each module's Kotlin main output directory (`core/.../kotlin/main`,
+  `gradle-plugin/.../kotlin/main`) and asserts **class-file major version 52**
+  (JDK 8) for all of them. Major version → Java mapping: 52=Java 8, 61=17,
+  69=25.
+- **Phase 0 sub-decision (resolved)**: keep the lightweight javap check. The
+  alternative — running the test suite on a JDK 8 runtime via Gradle toolchains
+  (foojay-resolver-convention + `JavaLanguageVersion.of(8)`) — adds a toolchain
+  download for no test coverage gain today (unit tests don't touch bytecode
+  compatibility). Revisit only if javap proves insufficient.
+
+### 3.3 `dependency-submit.yml` — least-privilege dependency graph submission
+
+- Triggered by `workflow_run` of `ci.yml` (`types: [completed]`), runs only
+  when that run succeeded, and does `dependency-graph: download-and-submit`.
+- Minimal by design: `download-and-submit` runs no Gradle build, so it needs no
+  checkout and no JDK — a single `setup-gradle` step.
+- Runs with `actions: read` + `contents: write` — the only job in the repo that
+  carries write access, and it never executes untrusted PR code.
+- `dependency-graph-continue-on-failure: false`: the job's sole purpose is the
+  submission, so a generate/submit failure must fail the workflow loudly
+  (contrast with `ci.yml`, where the graph is a side task of the build).
+
+### 3.4 `release.yml` (optional, Phase 6)
+
+- Trigger: tag push (`v*`).
+- Build + publish the Gradle plugin to the Plugin Portal
+  (`plugin-publish`), and optionally publish `core`/`exposed` artifacts to
+  JitPack (out-of-band, triggered by the tag) and/or Maven Central (OSSRH).
+- Requires secrets (`GRADLE_PUBLISH_KEY/SECRET`, `MAVEN_USERNAME/PASSWORD`,
+  GPG key) — configure in repo settings only when publishing is ready.
+
+### 3.5 `dependabot.yml` — landed (#169, merged)
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+```
+
+- `directory: "/"` scans the whole multi-module build (`core`,
+  `gradle-plugin`; `document` is excluded from the build) including the Gradle
+  wrapper and `gradle.properties`.
+- **No grouping** — keeps each dependency bump its own small PR, matching the
+  workflow rule.
+- Security updates are enabled by default and stay on (free).
+- Dependabot PRs run `ci.yml`; public-repo minutes are free, so this is fine.
+- Note: since Phase 0 removed most dead deps' resolution paths, Dependabot's
+  PRs against `kotlinx-html`, `kotlin-reflect`, JDBC drivers, etc. still open —
+  close (not merge) those;   the Phase 2 dead-dep PR removes them. Specifically,
+  the Phase 0 toolchain PR applied the same bumps as dependabot PRs **#171**
+  (dokka 2.2.0), **#172** (plugin-publish 2.1.1) and **#178** (wrapper 9.6.1) —
+  all three are now closed (Phase 0 merged).
+
+## 4. Action version policy
+
+- Pin by **major tag** (`@v4`) and let Dependabot keep them current. Full
+  SHA-pinning is optional hardening for stricter projects.
+- Recommended actions: `actions/checkout@v7` (in use since PR #170, Dependabot
+  bump v4 → v7), `gradle/actions/setup-gradle@v4`
+  (official Gradle action; replaces manual `setup-java` + cache for Gradle
+  projects), `actions/upload-artifact@v4` (if artifacts needed later).
+
+## 5. Student-plan notes
+
+- Public repo → unlimited Actions minutes; student pack covers private repos
+  (2,000 min/month). Treat minutes as plentiful but not free-for-all.
+- Conservation tactics used: PR-driven triggers, `paths-ignore` for docs,
+  `cancel-in-progress`, Gradle build cache via `setup-gradle`.
+- Dependabot has no per-run cost beyond the CI runs it triggers.
+
+## 6. Sequencing
+
+- **`dependabot.yml`**: **done** (#169, merged).
+- **`ci.yml` + `jvm8-bytecode.yml` + `dependency-submit.yml` + CircleCI
+  removal**: **done**, part of the Phase 0 toolchain PR.
+- **DB matrix job**: Phase 4 (with the `integration-test` module).
+- **`release.yml` + secrets**: Phase 6.
+
+## Definition of done
+
+- `ci.yml` green on JDK 25 for `./gradlew build` on PRs and `develop`/`master`
+  pushes; stale runs cancelled; docs-only changes skipped. — **done** (green on
+  PR #183: `build` + `jvm8-bytecode` both pass on JDK 25)
+- `jvm8-bytecode.yml` asserts class-file major version 52 for every produced
+  class on every build. — **done**
+- Dependency graph submitted via least-privilege split
+  (`generate-and-upload` in `ci.yml` → `download-and-submit` in
+  `dependency-submit.yml`); no job executes untrusted PR code with write
+  access. — **done**
+- Dependabot configured for `gradle` + `github-actions`, weekly, ungrouped. —
+  **done**
+- CircleCI config removed. — **done**

--- a/spec/ci.md
+++ b/spec/ci.md
@@ -25,9 +25,12 @@ PR), Phase 4 (DB integration tests) and Phase 6 (release publishing).
   Gradle 9 on a JDK 8 runtime to "prove" this — verification is done via the
   javap class-version check (§3.2).
 - Small changes per PR → CI is PR-driven, fast, and cancels stale runs.
-- User is on the GitHub **Student Developer Pack** (free tier). Public repos
-  get unlimited Actions minutes; the student plan covers private repos too.
-  Dependabot is free on all plans. Conservation is still good practice.
+- User is on the GitHub **Student Developer Pack**. This repo is **public**:
+  GitHub Actions minutes are free for public repos. (Private repos get a
+  monthly quota — 2,000 min on Free/Pro — and usage above it is billed; the
+  Student Developer Pack adds Pro benefits but does not waive usage-based
+  billing.) Dependabot is free on all plans. Conservation is still good
+  practice.
 
 ## 3. Workflows
 
@@ -36,8 +39,9 @@ PR), Phase 4 (DB integration tests) and Phase 6 (release publishing).
 As landed:
 
 - **Triggers**: `pull_request` (any) and `push` to `develop`/`master`.
-  `paths-ignore` for `README.md`, `spec/`, `docs/`, `document/` so docs-only
-  changes don't burn minutes.
+  `paths-ignore` for `README.md`, `spec/`, `docs/`, `document/` — changes
+  under those paths skip CI. Other doc-ish paths (e.g. `.opencode/**`,
+  `AGENTS.md`) are **not** ignored, so they still trigger CI.
 - **Permissions**: `contents: read` (least privilege) on every job — the build
   job **no longer escalates to `contents: write`**. The dependency graph is
   *generated and uploaded* here (`dependency-graph: generate-and-upload`) and
@@ -49,10 +53,10 @@ As landed:
 - **Steps**:
   - `actions/checkout@v7` with `persist-credentials: false` (no step needs Git
     authentication after checkout; Gradle doesn't use the persisted credential).
-  - `actions/setup-java@v4` with Temurin **JDK 25** — `setup-gradle` does **not**
-    install a JDK and ignores `distribution`/`java-version` inputs (only
-    `actions/setup-java` selects the JDK).
-  - `gradle/actions/setup-gradle@v4` with wrapper validation, build cache, and
+  - `actions/setup-java@v5.6.0` with Temurin **JDK 25** — `setup-gradle` does
+    **not** install a JDK and ignores `distribution`/`java-version` inputs
+    (only `actions/setup-java` selects the JDK).
+  - `gradle/actions/setup-gradle@v6` with wrapper validation, build cache, and
     `dependency-graph: generate-and-upload` (+
     `dependency-graph-continue-on-failure: true`) so Dependabot PRs resolve
     against an up-to-date dependency graph.
@@ -121,26 +125,32 @@ updates:
   workflow rule.
 - Security updates are enabled by default and stay on (free).
 - Dependabot PRs run `ci.yml`; public-repo minutes are free, so this is fine.
-- Note: since Phase 0 removed most dead deps' resolution paths, Dependabot's
-  PRs against `kotlinx-html`, `kotlin-reflect`, JDBC drivers, etc. still open —
-  close (not merge) those;   the Phase 2 dead-dep PR removes them. Specifically,
-  the Phase 0 toolchain PR applied the same bumps as dependabot PRs **#171**
-  (dokka 2.2.0), **#172** (plugin-publish 2.1.1) and **#178** (wrapper 9.6.1) —
-  all three are now closed (Phase 0 merged).
+- Note: Phase 2 (PR #184) removed the dead deps (`kotlinx-html-jvm` from
+  `gradle-plugin`, `kotlin-reflect`, JDBC drivers), so Dependabot no longer
+  opens PRs against them. Dependabot PRs **#171** (dokka 2.2.0), **#172**
+  (plugin-publish 2.1.1), and **#178** (wrapper 9.6.1) were superseded by the
+  Phase 0 toolchain PR and are closed. Later CI-action bumps merged: #170
+  (checkout v7), #191 (setup-gradle v6), #192 (setup-java v5.6.0). A Kotlin
+  `jvm` plugin bump (PR #193) is open with a **decline recommendation** — see
+  `spec/plan.md` §6.
 
 ## 4. Action version policy
 
-- Pin by **major tag** (`@v4`) and let Dependabot keep them current. Full
-  SHA-pinning is optional hardening for stricter projects.
-- Recommended actions: `actions/checkout@v7` (in use since PR #170, Dependabot
-  bump v4 → v7), `gradle/actions/setup-gradle@v4`
-  (official Gradle action; replaces manual `setup-java` + cache for Gradle
-  projects), `actions/upload-artifact@v4` (if artifacts needed later).
+- Pin by **major tag** (e.g. `@v7`) and let Dependabot keep them current;
+  Dependabot may propose full-version pins (e.g. `setup-java@v5.6.0`) — accept
+  those. Full SHA-pinning is optional hardening for stricter projects.
+- Recommended actions: `actions/checkout@v7` (PR #170), `gradle/actions/setup-gradle@v6`
+  (PR #191; official Gradle action — replaces manual `setup-java` + cache for
+  Gradle projects), `actions/setup-java@v5.6.0` (PR #192; Temurin JDK 25),
+  `actions/upload-artifact@v4` (if artifacts needed later). Dependabot keeps
+  them current.
 
-## 5. Student-plan notes
+## 5. Actions minutes & billing
 
-- Public repo → unlimited Actions minutes; student pack covers private repos
-  (2,000 min/month). Treat minutes as plentiful but not free-for-all.
+- Public repo → Actions minutes are **free**. If the repo ever goes private:
+  minutes are metered against the plan quota (2,000 min/month on Free/Pro) and
+  **usage above the quota is billed** — the Student Developer Pack adds Pro
+  benefits but does not waive usage-based billing.
 - Conservation tactics used: PR-driven triggers, `paths-ignore` for docs,
   `cancel-in-progress`, Gradle build cache via `setup-gradle`.
 - Dependabot has no per-run cost beyond the CI runs it triggers.

--- a/spec/ci.md
+++ b/spec/ci.md
@@ -39,9 +39,10 @@ PR), Phase 4 (DB integration tests) and Phase 6 (release publishing).
 As landed:
 
 - **Triggers**: `pull_request` (any) and `push` to `develop`/`master`.
-  `paths-ignore` for `README.md`, `spec/`, `docs/`, `document/` — changes
-  under those paths skip CI. Other doc-ish paths (e.g. `.opencode/**`,
-  `AGENTS.md`) are **not** ignored, so they still trigger CI.
+  `paths-ignore` for `README.md`, `spec/`, `docs/`, `document/`, `AGENTS.md`,
+  and `.opencode/**` — doc/config-only changes under those paths skip CI.
+  Workflow-file edits always trigger CI (GitHub ignores path filters for the
+  workflow's own files).
 - **Permissions**: `contents: read` (least privilege) on every job — the build
   job **no longer escalates to `contents: write`**. The dependency graph is
   *generated and uploaded* here (`dependency-graph: generate-and-upload`) and

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -1,0 +1,172 @@
+# Exposed Optionality — Design
+
+## Problem
+
+Users should be able to decide whether to use the Exposed ORM in their
+migrations. Consequences:
+
+- Harmonica must **compile and run without Exposed on the classpath**.
+- Users who *want* Exposed must be able to use the Exposed DSL inside a
+  migration's `up()`/`down()`.
+- The fear that motivated removing earlier code: *"if the user doesn't have
+  Exposed, compilation might fail."* Compilation fails only if harmonica's own
+  classes reference Exposed types at compile time. It must not.
+
+## Current state (from the code)
+
+- `core` has **no Exposed dependency** — good.
+- `core/.../Connection.kt` still carries a `hasExposed: Boolean` constructor
+  flag whose ternary returns the same value in both branches (dead code), plus
+  a commented-out `TransactionManager.current().connection`.
+- `gradle-plugin/.../PluginConfig.kt` detects Exposed at runtime via
+  `Class.forName("org.jetbrains.exposed.sql.Database")` — this is the right
+  *technique* (no compile-time reference), but the flag is not actually used
+  anywhere meaningful.
+- GitHub issues that this resolves: #91 (Exposed must be loadable by
+  `Class.forName`), #160 ("how to use with Exposed — AbstractMigration has no
+  `create` method"), #80 (Exposed version update — out of harmonica's control
+  once Exposed is user-supplied).
+
+## Design
+
+### 1. `core` = pure JDBC, zero Exposed knowledge
+
+- Remove the `hasExposed` constructor parameter and the dead ternary from
+  `Connection`.
+- Expose the underlying connection: add `val jdbcConnection: java.sql.Connection`
+  on **`ConnectionInterface`** (not only the concrete `Connection`). Semantics:
+  this returns the raw `coreConnection` — it does **not** trigger the silent
+  reconnect path (that would mask the close bug in issue #7).
+- Migration DSL (`AbstractMigration`, `TableBuilder`, adapters) stays JDBC-only.
+
+### 2. Optional integration module `harmonica-exposed`
+
+A tiny **separate artifact** (Gradle submodule, e.g. `exposed/`) that:
+
+- `api`-depends on `:core` and on `org.jetbrains.exposed:exposed-jdbc` (plus
+  `exposed-core`) at a pinned current version. `Database.connect(jdbcConnection)`
+  and `transaction()` live in `exposed-jdbc`, so it must be the JDBC module,
+  not just `exposed-core`.
+- Provides a bridge, e.g.:
+
+```kotlin
+fun AbstractMigration.exposedTransaction(block: () -> Unit) {
+    // Register Exposed ONCE per connection lifecycle, then reuse.
+    // Do NOT call Database.connect() on every invocation (that accumulates
+    // global registrations in TransactionManager and breaks on reconnect).
+    val db = (connection as? Connection)?.exposedDatabase()
+        ?: error("requires a com.improve_future.harmonica.core.Connection")
+    transaction(db) { block() }
+}
+```
+
+- The bridge is an extension on **`AbstractMigration`** (or the receiver is the
+  migration itself), because inside `up()` the receiver is `AbstractMigration`
+  and its `connection` field is typed `ConnectionInterface` — an extension on
+  the concrete `Connection` would not resolve. See Pitfall E below.
+
+### 2.1 Transaction ownership (the critical design point)
+
+The migration runner already wraps `up()`/`down()` in
+`Connection.transaction` (`MigrationUpTask.kt:21-27`, `JarmonicaUpMain.kt:27-34`),
+which commits, and on failure rolls back **and closes** the connection
+(`Connection.kt:107-117`). Running Exposed's own `transaction(db){}` on the
+**same physical connection** produces a nested commit/rollback pair (harmless
+on success; on failure a double-rollback plus a stale Exposed `Database`
+pointing at the closed connection).
+
+Decide **one owner** (open question #3):
+
+- **Option A (recommended): harmonica owns the transaction.** The bridge binds
+  harmonica's connection into Exposed's manager and runs the Exposed DSL
+  *without* an Exposed-managed commit (i.e. `TransactionManager`/stack-based
+  registration, or `transaction(db){}` where the commit is a no-op because the
+  outer `Connection.transaction` commits). Users write the Exposed DSL; harmonica
+  does commit/rollback/close.
+- **Option B: Exposed owns the transaction.** Then the harmonica runner must
+  NOT wrap migrations in `Connection.transaction` when the bridge is used
+  (require an explicit opt-in), and harmonica's `Connection.transaction` is
+  bypassed.
+
+Until this is decided, the snippet is illustrative only and must not be shipped
+as written.
+
+### 2.2 Other pitfalls to design around
+
+- **`setTransactionIsolation` no-op proxy**: `Connection.connect()` wraps every
+  non-SQLite JDBC connection in a proxy that overrides `setTransactionIsolation`
+  to a no-op (`Connection.kt:18`). Exposed may derive isolation from its own
+  config and try to apply it — it will be silently ignored. Acceptable for now;
+  document it, or decide whether the proxy override is still needed at all.
+- **Reconnect invalidation**: the proxy is recreated on every reconnect
+  (`Connection.kt:29-38`). A cached Exposed `Database` bound to an old connection
+  is stale. The bridge must re-register after reconnect (key the cache by
+  connection instance) or, per Option A, register fresh within each migration.
+- **Single-threaded assumption**: `Database.connect(java.sql.Connection)`
+  reuses one shared connection for every transaction and is not thread-safe.
+  The migration runner is single-threaded, so this holds — document it.
+- **`autoCommit`**: harmonica forces `autoCommit = false` (connect + at the top
+  of `transaction`). Exposed transactions assume `autoCommit = false` too;
+  verify the pinned Exposed version doesn't restore `autoCommit = true` after a
+  transaction (harmonica's next `transaction` self-heals via `Connection.kt:108`).
+- **Name collision**: `core` has an (empty) `com.improve_future.harmonica.core.Database`
+  class (`Database.kt`). Avoid wildcard imports in the bridge so it doesn't
+  collide with `org.jetbrains.exposed.sql.Database`.
+- **Script classpath (Pitfall F)**: migration `.kts` files are evaluated by the
+  Gradle plugin's JSR-223 engine on the **plugin's classpath**
+  (`AbstractMigrationTask.kt:33-38`). Adding `harmonica-exposed` via the user's
+  `implementation(...)` is not enough — the bridge/Exposed must be reachable by
+  the script engine. Options: a plugin-managed configuration appended to the
+  script classpath, or `buildscript { dependencies { classpath(...) } }`.
+  Design this explicitly in Phase 3.
+
+### 3. No `Class.forName` special-casing in core
+
+- Runtime reflection detection in the Gradle plugin was a workaround for when
+  core *did* reference Exposed. Once core is clean, delete it unless we keep
+  `PluginConfig.hasExposed()` purely for diagnostics/docs.
+- Plugin behavior must be identical with or without Exposed present.
+
+### 4. User story (both ways)
+
+Without Exposed (default):
+
+```kotlin
+class M20260801_Migrate : AbstractMigration() {
+    override fun up() {
+        createTable("users") { varchar("name", 100) }
+    }
+}
+```
+
+With Exposed (opt-in artifact + user's own Exposed dependency):
+
+```kotlin
+class M20260801_Migrate : AbstractMigration() {
+    override fun up() {
+        exposedTransaction {
+            // Exposed DSL here; runs inside harmonica's connection/transaction
+        }
+    }
+}
+```
+
+## Verification / Definition of done
+
+- `./gradlew :core:compileKotlin` and full build succeed **without** Exposed on
+  the classpath anywhere.
+- `./gradlew :core:dependencies` shows no `exposed` modules.
+- A test/demo project compiles a migration using the Exposed DSL and runs it
+  against a real DB.
+- `Connection` has no `hasExposed` flag; `PluginConfig` no longer special-cases
+  Exposed (or uses it only for diagnostics).
+- Documented in README + wiki with the two usage paths above.
+
+## Open questions
+
+- Publish `harmonica-exposed` as a separate artifact, or start with a
+  documented snippet and promote to an artifact later?
+- Exact Exposed version to use in the bridge (match user expectations; keep it
+  a normal version range).
+- Whether `exposedTransaction` should manage commit/rollback or delegate to
+  `Connection.transaction`.

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -28,11 +28,13 @@ migrations. Consequences:
   `Class.forName("org.jetbrains.exposed.sql.Database")` — this is the right
   *technique* (no compile-time reference), but the flag is not actually used
   anywhere meaningful.
-- **Bridge contract**: the bridge targets a **single supported Exposed major**
-  — the current `exposed-jdbc` line (package `org.jetbrains.exposed.sql`,
-  `Database.connect(DataSource)` + `transaction()` APIs). If a future Exposed
-  major changes these APIs, the detection class name in `PluginConfig.kt` and
-  the bridge must move together; never support two majors in one bridge.
+- **Bridge contract**: the bridge targets a **single supported Exposed major**:
+  **Exposed 0.x** — the major whose JDBC API lives in package
+  `org.jetbrains.exposed.sql` (`Database.connect(DataSource)` +
+  `transaction()`), matching the runtime detection string in `PluginConfig.kt`.
+  Exposed 1.x moved these classes to `org.jetbrains.exposed.v1.jdbc.*`, so
+  adopting 1.x requires updating the detection class name and bridge APIs
+  together; never support two majors in one bridge.
 - GitHub issues that this resolves: #91 (Exposed must be loadable by
   `Class.forName`), #160 ("how to use with Exposed — AbstractMigration has no
   `create` method"), #80 (Exposed version update — out of harmonica's control
@@ -185,7 +187,7 @@ class M20260801_Migrate : AbstractMigration() {
 
 - Publish `harmonica-exposed` as a separate artifact, or start with a
   documented snippet and promote to an artifact later?
-- Exact Exposed version to use in the bridge (match user expectations; keep it
-  a normal version range).
+- Exact Exposed **0.x** version to use in the bridge (match user expectations;
+  keep it a normal version range within the 0.x line).
 - Whether `exposedTransaction` should manage commit/rollback or delegate to
   `Connection.transaction`.

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -1,5 +1,11 @@
 # Exposed Optionality — Design
 
+> **Status: design only (Phase 3, not started).** `harmonica-exposed` does not
+> exist yet and `exposedTransaction` is a proposed **future** API. Nothing in
+> this document is shipped or supported until the artifact, the script-classpath
+> handling, transaction tests, and real-DB verification land in Phase 3. Issue
+> #91 stays open until then.
+
 ## Problem
 
 Users should be able to decide whether to use the Exposed ORM in their
@@ -22,6 +28,11 @@ migrations. Consequences:
   `Class.forName("org.jetbrains.exposed.sql.Database")` — this is the right
   *technique* (no compile-time reference), but the flag is not actually used
   anywhere meaningful.
+- **Bridge contract**: the bridge targets a **single supported Exposed major**
+  — the current `exposed-jdbc` line (package `org.jetbrains.exposed.sql`,
+  `Database.connect(DataSource)` + `transaction()` APIs). If a future Exposed
+  major changes these APIs, the detection class name in `PluginConfig.kt` and
+  the bridge must move together; never support two majors in one bridge.
 - GitHub issues that this resolves: #91 (Exposed must be loadable by
   `Class.forName`), #160 ("how to use with Exposed — AbstractMigration has no
   `create` method"), #80 (Exposed version update — out of harmonica's control
@@ -44,7 +55,7 @@ migrations. Consequences:
 A tiny **separate artifact** (Gradle submodule, e.g. `exposed/`) that:
 
 - `api`-depends on `:core` and on `org.jetbrains.exposed:exposed-jdbc` (plus
-  `exposed-core`) at a pinned current version. `Database.connect(jdbcConnection)`
+  `exposed-core`) at a pinned current version. `Database.connect(DataSource)`
   and `transaction()` live in `exposed-jdbc`, so it must be the JDBC module,
   not just `exposed-core`.
 - Provides a bridge, e.g.:
@@ -59,6 +70,13 @@ fun AbstractMigration.exposedTransaction(block: () -> Unit) {
     transaction(db) { block() }
 }
 ```
+
+  `exposedDatabase()` adapts the underlying `jdbcConnection` (exposed on
+  `ConnectionInterface`, §1) into a **single-connection `DataSource`** and calls
+  `Database.connect(dataSource)` **once** per connection lifecycle. The
+  `DataSource` overload is used because it is the supported connect form across
+  the pinned Exposed major; the same DataSource is reused for the whole
+  migration so the transaction owner is stable.
 
 - The bridge is an extension on **`AbstractMigration`** (or the receiver is the
   migration itself), because inside `up()` the receiver is `AbstractMigration`
@@ -102,9 +120,10 @@ as written.
   (`Connection.kt:29-38`). A cached Exposed `Database` bound to an old connection
   is stale. The bridge must re-register after reconnect (key the cache by
   connection instance) or, per Option A, register fresh within each migration.
-- **Single-threaded assumption**: `Database.connect(java.sql.Connection)`
-  reuses one shared connection for every transaction and is not thread-safe.
-  The migration runner is single-threaded, so this holds — document it.
+- **Single-threaded assumption**: `Database.connect(DataSource)` wrapping one
+  connection reuses that connection for every transaction and is not
+  thread-safe. The migration runner is single-threaded, so this holds —
+  document it.
 - **`autoCommit`**: harmonica forces `autoCommit = false` (connect + at the top
   of `transaction`). Exposed transactions assume `autoCommit = false` too;
   verify the pinned Exposed version doesn't restore `autoCommit = true` after a
@@ -114,7 +133,7 @@ as written.
   collide with `org.jetbrains.exposed.sql.Database`.
 - **Script classpath (Pitfall F)**: migration `.kts` files are evaluated by the
   Gradle plugin's JSR-223 engine on the **plugin's classpath**
-  (`AbstractMigrationTask.kt:33-38`). Adding `harmonica-exposed` via the user's
+  (`AbstractMigrationTask.kt:33-37`). Adding `harmonica-exposed` via the user's
   `implementation(...)` is not enough — the bridge/Exposed must be reachable by
   the script engine. Options: a plugin-managed configuration appended to the
   script classpath, or `buildscript { dependencies { classpath(...) } }`.

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -15,11 +15,11 @@ PR #183), #165 (LICENSE already MIT; README badge URLs fixed, PR #181), #140
 (kotlin-pluralizer removed, internal `singularize()`, PR #187).
 
 **Closed / superseded (were listed as URGENT, now resolved on `develop`):**
-#159 (build failure Win10 openjdk 15), #158 (build failure Win/Linux
-openjdk 16), and #162 (Build on Java 17) are all **closed** — same root cause
-(old Kotlin 1.4.20 toolchain on new JDKs), fixed by the Phase 0 toolchain
-upgrade; drop them from active tracking. PR #163 ("update to JDK 17") is now
-**closed** — superseded by Phase 0.
+the build-failure issues #159 (Win10 openjdk 15), #158 (Win/Linux openjdk 16),
+and #162 (Build on Java 17) are all **closed** — same root cause (old Kotlin
+1.4.20 toolchain on new JDKs), fixed by the Phase 0 toolchain upgrade; drop
+them from active tracking. PR #163 ("update to JDK 17") is now **closed** —
+superseded by Phase 0.
 
 ## SMALL — quick wins (Phase 5)
 

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,0 +1,79 @@
+# GitHub Issue Triage
+
+Snapshot of **open** issues on 2026-08-01 (**30 open** total). Grouped by
+urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
+upgrade in Phase 0/2.
+
+## URGENT — blocking restart
+
+| # | Title | Plan |
+| --- | --- | --- |
+| 153 | Tasks in jarmonica gradle plugin don't work anymore | Investigate during Phase 5; add tests (ties into #97). |
+
+**Resolved by Phase 0/2 (ready to close):** #167 (jcenter removed, CI rewritten,
+PR #183), #165 (LICENSE already MIT; README badge URLs fixed, PR #181), #140
+(kotlin-pluralizer removed, internal `singularize()`, PR #187).
+
+**Closed / superseded (were listed as URGENT, now resolved on `develop`):**
+#159 (build failure Win10 openjdk 15), #158 (build failure Win/Linux
+openjdk 16), #162 (Build on Java 17), and #182 (README JitPack badge) are all
+**closed**; drop them from active tracking — same root cause (Kotlin 1.4.20 on
+new JDK) / same fix (Phase 6 first release). PR #163 ("update to JDK 17",
+open WIP) is now **closed** — superseded by Phase 0.
+
+## SMALL — quick wins (Phase 5)
+
+| # | Title | Plan |
+| --- | --- | --- |
+| 189 | `isSubtypeOf` in scanner swallows all `Throwable` | Narrow to recoverable exceptions to match `loadClass` (PR #188); small fix in `JarmonicaTaskMain`. |
+| 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
+| 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |
+| 91 | Exposed Library must be loaded by Class.forName | Resolved by [exposed-integration.md](exposed-integration.md): core has no Exposed reference. |
+| 138 | Is there a need to make AbstractColumn internal? | Open up custom-column extension points (make `AbstractColumn`/`ColumnBuilder` public, document custom column pattern). |
+| 141 | Add support to more column types | Long is done; add Enumeration and other missing types (see Exposed type list). |
+| 145 | Add alter column function | Add `alterColumn` to change type/options. |
+| 67 | Default value for timestamp | Medium-ish small: default `DEFAULT CURRENT_TIMESTAMP` (or constant) for `createTimestamp` etc.; ties into #85 SQLite-defaults research. |
+| 139 | Update addForeignKey | Support ON DELETE / ON UPDATE / constraint options. |
+| 69 | Add sophisticated query executing method | Provide richer `executeQuery`/query-returning API. |
+| 4 | add timestamp syntax to add created_at and updated_at | Convenience columns/timestamps helper. |
+
+## MEDIUM
+
+| # | Title | Plan |
+| --- | --- | --- |
+| 7 | Sometimes migration stops because of closed connection | Reproduce & fix connection lifecycle (README "Caution" section documents a workaround). |
+| 85 | Research SQLite default value in other migration tools | Research rails/phinx behavior; align `createTime`/`createDateTime`/`createTimestamp` defaults for SQLite. |
+| 80 | Update exposed version | Out of harmonica's control once Exposed is optional (see exposed-integration.md); document supported version. |
+| 71 | consider to add or not seeding function | Decide scope; if yes, design a `seed` task. |
+| 97 | Add Test to Sub Classes of JavaExec | Gradle TestKit tests for `JarmonicaMigrationTask` and friends. |
+| 155 | [feature] Programmatic migrations and/or documentation for it | Document programmatic API + add convenience entry points. |
+
+## LARGE / STRATEGIC (separate designs & PRs)
+
+| # | Title | Plan |
+| --- | --- | --- |
+| 1 | put into maven central | Publishing target — decide JitPack vs Maven Central (Phase 6 open decision). |
+| 125 | Handle Multiple database | Multi-DB config; sizable design. |
+| 121 | Dry run | `-Pdry` SQL preview (PostgreSQL first). |
+| 148 | Maven support | There is a `feature/maven-plugin` branch — evaluate resurrecting it. |
+| 147 | Java support | Kotlin-first but make Java API ergonomic (Java-friendly DSL/annotations). |
+| 105 | Separate DB Adapter files and migration | Plugin-able adapter SPI so others can add DBMS without modifying core. |
+| 107 | Update SQL Server Adapter | Finish missing methods in `SqlServerAdapter`. |
+| 41 | Autogenerate migrations | Diff schemas and generate migration files. |
+| 20 | Research other tools | Compare rails/phinx/flyway/liquibase features; use to prioritize. |
+
+## Closed-but-related (context)
+
+- #168 (PR, merged): bug-build-issue — build fixes already on `develop`.
+- #160 (closed): "How it should be used with Exposed" — reopened conceptually in
+  exposed-integration.md.
+- #164 (PR, not merged): actual title **"Task/boko 49"** — a closed PR; not an
+  issue and not part of active triage (was previously miscatalogued).
+- #163 (PR, "update to JDK 17") — **closed**; superseded by Phase 0.
+
+## Process
+
+- Close issues that the Phase 0/2 upgrades resolve, referencing the PR.
+- Convert "small" items into a backlog with acceptance criteria before starting
+  Phase 5.
+- Keep "large/strategic" items open as RFCs until a design doc exists.

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-01 (**30 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-08 (**28 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 
@@ -10,22 +10,23 @@ upgrade in Phase 0/2.
 | --- | --- | --- |
 | 153 | Tasks in jarmonica gradle plugin don't work anymore | Investigate during Phase 5; add tests (ties into #97). |
 
-**Resolved by Phase 0/2 (ready to close):** #167 (jcenter removed, CI rewritten,
+**Resolved and closed by Phase 0/2:** #167 (jcenter removed, CI rewritten,
 PR #183), #165 (LICENSE already MIT; README badge URLs fixed, PR #181), #140
 (kotlin-pluralizer removed, internal `singularize()`, PR #187).
 
 **Closed / superseded (were listed as URGENT, now resolved on `develop`):**
 #159 (build failure Win10 openjdk 15), #158 (build failure Win/Linux
-openjdk 16), #162 (Build on Java 17), and #182 (README JitPack badge) are all
-**closed**; drop them from active tracking — same root cause (Kotlin 1.4.20 on
-new JDK) / same fix (Phase 6 first release). PR #163 ("update to JDK 17",
-open WIP) is now **closed** — superseded by Phase 0.
+openjdk 16), and #162 (Build on Java 17) are all **closed** — same root cause
+(old Kotlin 1.4.20 toolchain on new JDKs), fixed by the Phase 0 toolchain
+upgrade; drop them from active tracking. PR #163 ("update to JDK 17") is now
+**closed** — superseded by Phase 0.
 
 ## SMALL — quick wins (Phase 5)
 
 | # | Title | Plan |
 | --- | --- | --- |
 | 189 | `isSubtypeOf` in scanner swallows all `Throwable` | Narrow to recoverable exceptions to match `loadClass` (PR #188); small fix in `JarmonicaTaskMain`. |
+| 182 | README JitPack badge shows nothing | Fix JitPack badge so it renders (README badge URLs fixed in PR #181, but this badge still broken). |
 | 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
 | 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |
 | 91 | Exposed Library must be loaded by Class.forName | Resolved by [exposed-integration.md](exposed-integration.md): core has no Exposed reference. |
@@ -34,7 +35,7 @@ open WIP) is now **closed** — superseded by Phase 0.
 | 145 | Add alter column function | Add `alterColumn` to change type/options. |
 | 67 | Default value for timestamp | Medium-ish small: default `DEFAULT CURRENT_TIMESTAMP` (or constant) for `createTimestamp` etc.; ties into #85 SQLite-defaults research. |
 | 139 | Update addForeignKey | Support ON DELETE / ON UPDATE / constraint options. |
-| 69 | Add sophisticated query executing method | Provide richer `executeQuery`/query-returning API. |
+| 69 | Add sophisticated query executing method | Provide a richer `executeQuery`/query-returning API. |
 | 4 | add timestamp syntax to add created_at and updated_at | Convenience columns/timestamps helper. |
 
 ## MEDIUM

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -1,0 +1,308 @@
+# Harmonica — Master Plan
+
+Restart development of Harmonica (Kotlin DB migration tool) after a pause of
+several years. This plan is the single source of truth for the restart.
+
+## 1. Goals
+
+1. Make the project build and test green again on a modern toolchain.
+2. Remove license header comments from all source files.
+3. Upgrade all library versions to current, maintained releases.
+4. Make the Exposed ORM an **optional** user choice (no compile-time dependency
+   on Exposed in `core`; users opt in).
+5. Bring real-DB tests into this repository (merge `harmonica_test`).
+6. Publish via JitPack (jcenter/bintray are dead) and keep the Gradle plugin on
+   the Plugin Portal.
+7. Work through the GitHub issue backlog, quick wins first.
+8. Prepare local DB environments for development/testing.
+
+## 2. Constraints
+
+- Target bytecode for the published library: **JVM 8** (`jvmTarget = 1.8`).
+- The only JDK on this machine is **OpenJDK 25** → Gradle must run on Java 25.
+- Kotlin version: **2.3.20** (chosen by maintainer). Note: Kotlin 2.3 no
+  longer supports `-language-version=1.8` (source level), but `jvmTarget =
+  1.8` bytecode remains supported — verified in Phase 0 with no deprecation
+  warning under 2.3.20 (only the old `kotlinOptions` DSL is deprecated, which
+  this build doesn't use).
+- No Docker installed locally (yet). DB-backed tests must not break local builds.
+- Do not force Exposed onto users; their migration classpath decides.
+
+## 3. Branch & release strategy (master is stale)
+
+State:
+
+- `master` (origin/master @ `3b423c6`) has not been touched in years and is the
+  direct ancestor of `develop` (merge-base == master HEAD).
+- `develop` is 54 commits ahead (module split into `core`/`gradle-plugin`,
+  jcenter removal work, MIT license change, etc.) but **never fully tested or
+  released** — this is why master was left behind.
+
+Policy going forward (Git Flow, simplified):
+
+1. `develop` is the integration branch; feature/phase branches are cut from it.
+2. A release branch/tag is created from `develop` only when CI is fully green
+   and manual DB tests pass.
+3. The very first milestone of this restart is: make `develop` build green →
+   then fast-forward `master` to `develop` → tag the first new release there.
+   (Because `master` is an ancestor, this is a clean fast-forward, no merge
+   conflict risk.)
+4. `master` becomes the source of released tags (JitPack builds from tags).
+5. Old branches on the remote (`feature/core_split`, `feature/maven-plugin`,
+   `feature/version_up`, `feature/exposed`, `feature/show_sql`, `feature/mit-license`,
+   `feature/split`) are either resurrected as issues or deleted after review.
+
+## 3.5. Risk register — unverified changes already on `develop`
+
+`develop` contains changes that were merged with limited or no testing:
+
+- **Module split** (`feature/split`, PR #161): the project was split into
+  `core`, `gradle-plugin`, and `document`. The maintainer merged it based on
+  review rather than thorough testing. This is the biggest untested change and
+  may carry API/packaging/plugin breakage.
+- **jcenter removal + POM/publication work** (commits after the split): build
+  config was edited to remove bintray/jcenter, but never verified end-to-end
+  (see issue #167, which surfaced later).
+- **Gradle Groovy → Kotlin DSL migration** (included in the split work).
+
+Consequences for the restart:
+
+- Treat all of `develop` as **unverified baseline**. Phase 0 must get the split
+  build green and prove `core`, `gradle-plugin`, and `document` all build,
+  test, and package correctly.
+- Do not assume the module split is correct as-is; budget time in Phase 0 to
+  fix packaging, plugin application, and publication.
+- These unverified changes are the reason `master` was left behind — do not
+  fast-forward `master` until Phase 0 is green and DB tests (Phase 4) pass.
+
+## 4. Phases
+
+Each phase lands as its own branch + PR into `develop`. Definition of done for
+each phase: `./gradlew build` passes on this machine (Java 25) with the phase's
+changes, and CI is green.
+
+### Phase 0 — Toolchain upgrade & CI (blocking, do first)
+
+Outcome: project compiles and tests on Java 25; CI works.
+
+Status: **implemented and merged (2026-08-01, PR #183, merge commit
+`69344da`).** `./gradlew clean build` is green locally on Java 25 and in CI.
+
+- Upgrade Gradle wrapper to **9.1.x or newer** — done: **9.6.1** (wrapper jar/
+  scripts regenerated via `./gradlew wrapper`). Bootstrap trick used: the old
+  6.5 wrapper jar can still download a new distribution, so
+  `gradle/wrapper/gradle-wrapper.properties` was hand-edited first.
+- Upgrade Kotlin to **2.3.x** — done: **2.3.20**; `jvmTarget = 1.8` set via
+  `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }` +
+  `java.sourceCompatibility/targetCompatibility` in `core` and
+  `gradle-plugin`. Verified: no deprecation warning for `jvmTarget 1.8`, and
+  all main classes are class-file major 52.
+- Rewrite `build.gradle.kts` for modern Gradle/Kotlin DSL — done: root now a
+  `plugins {}` block (`kotlin("jvm") 2.3.20 apply false`, plugin-publish
+  **2.1.1**, dokka   **2.2.0**); `settings.gradle.kts` has `pluginManagement`;
+  `document/` removed from `include(...)`.
+- **Source modernization (compile-blocker on Gradle 9)** — done:
+  `JarmonicaPlugin.kt` uses `JavaPluginExtension` + `tasks.register` (no
+  `JavaPluginConvention`/`conventionMapping`/`groovyClosure`); `HarmonicaPlugin.kt`
+  uses `tasks.register(name, Class) { task -> ... }`. Gradle 9-specific: the
+  Jarmonica task subclasses are declared `abstract` (`JavaExec` is abstract in
+  Gradle 9) and every task type carries `@DisableCachingByDefault`
+  (`validatePlugins` requires a caching annotation).
+- **Script engine migration** — done: `kotlin-script-runtime` +
+  `kotlin-script-util` replaced by `kotlin-scripting-jsr223:2.3.20`
+  (`kotlin-script-util` no longer exists for 2.3.x). The engine class moved to
+  `kotlin.script.experimental.jsr223`; `AbstractMigrationTask` now uses plain
+  `javax.script.ScriptEngine` + `getEngineByName("kotlin")`, and the plugin's
+  committed `META-INF/services/javax.script.ScriptEngineFactory` was **deleted**
+  (it pointed at the removed `org.jetbrains.kotlin.script.jsr223.*` factory; the
+  dependency registers its own).
+- **Coordinates/IDs**: still open. The legacy `pluginBundle` block (published
+  id `com.improve_future.harmonica`) was removed by the plugin-publish 2.x
+  migration; applied/published ids are now `harmonica`/`jarmonica`. The stale
+  descriptor `META-INF/gradle-plugins/com.improve_future.harmonica.properties`
+  is still bundled. Reconcile in Phase 6.
+- **`document/` module**: decided — **dropped from the root build**, folder
+  left as-is (own Gradle 4.9 wrapper, version-less Kotlin plugin, deprecated
+  `mainClassName`). No longer compiled or released. Future: convert or remove
+  (Phase 7).
+- Fix CI — done, part of this PR (see [ci.md](ci.md)): `ci.yml` (PR-driven,
+  JDK 25, `./gradlew build`, dependency-graph submission) + `jvm8-bytecode.yml`
+  (javap major-version 52 check) replace `gradle.yml` and `.circleci/config.yml`
+  (both deleted). `.github/dependabot.yml` already landed (#169).
+- After green: fast-forward `master` to `develop` (first milestone).
+
+### Phase 1 — License header removal
+
+Outcome: all source files have no license comment header; LICENSE/README keep
+the MIT notice.
+
+Status: **landed 2026-08-01.** License headers stripped from all 87 files
+(86 source files + 1 extensionless `META-INF/services/...` registration file;
+PR #180); README badges fixed (PR #181 — MIT URL → opensource.org, bintray
+badge → JitPack). Remaining jcenter reference:
+`document/.../JarmonicaView.kt:61` (doc-string only).
+
+Original plan (kept for reference):
+
+- Remove the 7-line MIT header block from every `.kt`, `.kts`, `.gradle`,
+  `.properties`, and resource file (86 source files; do not touch generated
+  `docs/api/**`).
+- Do not touch `LICENSE` (repo-level license file stays).
+- Add a small script (e.g. `scripts/strip-license-headers.sh`) or use `sed`
+  in one commit; keep it reproducible.
+- Fix README badges: bintray badge → JitPack badge; MIT badge URL points at
+  GPL-3.0 — fix to the MIT URL (issue #165 cleanup).
+
+### Phase 2 — Dependency upgrades
+
+Outcome: no dead repositories or unmaintained libraries in the build.
+
+Status: **merged 2026-08-01 (PRs #184-#188).** All build files now use only
+Maven Central (`document/` excluded from build). 72 tests green (68 core + 4
+gradle-plugin; Phase 0 baseline was 66).
+
+- `gradle.properties`: `kotlin_version` → 2.3.x. — **done in Phase 0** (2.3.20).
+- Dead repositories: **gone** — jcenter/bintray/space removed; jitpack removed
+  from `core` and `gradle-plugin` with pluralizer removal (PR #187).
+- `core`:
+  - `kotlin-pluralizer` (jitpack, unmaintained, issue #140) → **removed**;
+    internal `singularize()` ported into `core/.../table/Inflections.kt`
+    (PR #187, decision in §6).
+  - `commons-codec` 1.15 → **dropped** (no usage; PR #184).
+  - JUnit Jupiter 5.4.2 → **6.1.2** (PR #186; decision in §6);
+    `kotlin-test` → current (**done in Phase 0**, pinned to 2.3.20).
+- `gradle-plugin`:
+  - `kotlin-script-runtime`/`kotlin-script-util` → `kotlin-scripting-jsr223` —
+    **done in Phase 0** (JSR-223 migration).
+  - `org.reflections` 0.9.11 → **replaced** with a lightweight classpath
+    scanner in `JarmonicaTaskMain` (PR #185; `loadClass` narrowed to
+    recoverable exceptions in PR #188 — remaining `isSubtypeOf` `catch
+    (Throwable)` tracked in issue #189).
+  - `kotlinx-html-jvm` 0.7.3 → **dropped here** (unused in this module; only
+    `document` uses it — upgrade there, Phase 7).
+  - `kotlin-reflect` → **dropped** (only stdlib `KClass` usage; PR #184).
+  - `kotlin-test`/`kotlin-test-junit5` are **unversioned** here — pin to 2.3.x.
+    **done in Phase 0** (now pinned).
+  - JDBC test drivers (mysql 5.1.44, postgresql 9.4.1212.jre6, sqlite 3.21.0.1,
+    mssql 6.2.1.jre7) → **removed** (unused by any test; PR #184); integration
+    DB drivers move to the Phase 4 integration module.
+  - `com.gradle.plugin-publish` 0.9.10 → current 1.x; Dokka 0.9.17 → 2.x.
+    **done in Phase 0** (plugin-publish 2.1.1, dokka 2.2.0).
+- `document` module: see Phase 0 — convert to a proper subproject (upgrade its
+  own wrapper, pin Kotlin, fix `mainClassName`) or drop it from the release.
+  Upgrade `kotlinx-html-jvm` 0.7.3 → latest there; drop `groovy-all` 2.3.11 if
+  unused after conversion.
+
+### Phase 3 — Exposed optionality
+
+Outcome: `core` has zero Exposed references; users decide whether to use
+Exposed, and integration is documented. Full design: [exposed-integration.md].
+
+Status: **not started — next phase.**
+
+- Remove dead `hasExposed` flag plumbing from `Connection.kt` (currently a
+  no-op ternary).
+- Expose the underlying `java.sql.Connection` from `Connection`.
+- Provide an **optional** artifact/module `harmonica-exposed` that bridges
+  Exposed transactions onto harmonica's connection lifecycle (users who add it
+  get Exposed; everyone else is unaffected — compilation cannot fail).
+- Keep runtime detection (`Class.forName`) only where it adds value; otherwise
+  delete `PluginConfig.hasExposed()`.
+- Resolve issues #91, #80 and the concern behind #160 (document, upgrade,
+  reflect).
+
+### Phase 4 — Tests & DB environment
+
+Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
+
+- Merge relevant tests from `KenjiOhtsuka/harmonica_test` into a new
+  `integration-test` module or a dedicated source set.
+- Local DBs: install Docker (or use system Postgres/MySQL) and document setup;
+  provide `docker-compose.yml` for PostgreSQL/MySQL; SQLite and H2 need no
+  server and are covered by Docker-free embedded-DB tests (see
+  [`testing.md`](testing.md)).
+- Tests that need a DB are gated (skip when DB unavailable) so `./gradlew build`
+  never fails locally without Docker.
+- CI runs DB-backed tests using Docker services.
+- Decide test framework/tooling (JUnit 5 + Testcontainers preferred).
+
+### Phase 5 — Issue backlog (quick wins first)
+
+Full triage: [issues-triage.md]. Order:
+
+1. Urgent blockers: #153 (ties into #97). #167 and #162 are resolved — the
+   toolchain/CI fixes landed in Phase 0 (#183); #158, #159 are already closed
+   (verified; not tracked here).
+2. Small: #165 (README/license URLs), #140 (pluralizer), #26 (migration file
+   naming), #47 (prepared statements), #91 (Exposed), #138 (custom columns),
+   #141 (more column types), #145 (alter column), #139 (FK options), #69
+   (query execution API), #4 (created_at/updated_at).
+3. Medium: #7 (closed connection), #85 (SQLite defaults), #67 (timestamp
+   default), #80 (Exposed version), #71 (seeding), #97 (JavaExec task tests),
+   #155 (programmatic migration docs).
+4. Large/strategic (separate designs/PRs): #1 (Maven Central), #125 (multiple
+   DBs), #121 (dry run), #148 (Maven support — see `feature/maven-plugin`
+   branch), #147 (Java support), #105 (adapter plugin API), #107 (SQL Server
+   adapter), #41 (auto-migrations), #20 (research).
+
+### Phase 6 — Release & publishing
+
+- Configure **JitPack**: build from git tags; multi-module must produce
+  `com.improve_future.harmonica:harmonica-core` (or keep group/module names
+  stable). Verify with a snapshot tag.
+- Keep Gradle Plugin Portal publication (`plugin-publish`) for
+  `com.improve_future.harmonica`.
+- Decide on Maven Central (OSSRH) as a secondary channel; needs GPG signing
+  and credentials — treat as optional.
+- Update README: install instructions, JitPack badge, wiki command docs,
+  remove bintray references, update "not developed actively" notice.
+
+### Phase 7 — Documentation refresh
+
+- Rewrite README with current usage (also for the new Exposed-optional flow).
+- Update/regenerate API docs with modern Dokka.
+- Keep `document/` site in sync or remove it if unmaintainable.
+
+## 5. Definition of done (overall restart)
+
+- `./gradlew build` green on this machine (Java 25) and on CI.
+- License headers gone from all source files.
+- No dead repositories (jcenter/bintray) anywhere in the build or docs.
+- Exposed fully optional, with docs and at least one example each way.
+- Real-DB tests merged and runnable; local DB setup documented.
+- First new release tagged; `master` fast-forwarded; JitPack build verified.
+- Open-issue count reduced (all "urgent/small" closed or converted to tasks).
+- `harmonica_demo` left untouched (documented only, not part of the restart).
+
+## 5.5. Workflow rule
+
+- **Small changes per PR**: each license-strip, dependency removal, badge fix,
+  or issue fix is its own PR against `develop`. The only sanctioned exception
+  is the Phase 0 toolchain PR, which must move Gradle 9 + Kotlin 2.3 +
+  buildscript rewrite + source modernization together (they cannot be split
+  without leaving the build permanently red).
+
+## 6. Open decisions
+
+Resolved (2026-08-01):
+
+- Kotlin patch pinned: **2.3.20**.
+- Gradle pinned: **9.6.1**.
+- `document` module: **dropped from the root build** (folder kept, excluded from
+  settings).
+- JVM-8 verification: **javap class-version check** (`jvm8-bytecode.yml`), not a
+  JDK-8 toolchain test run (see [`ci.md`](ci.md) §3.2).
+- Pluralization: **implement internally** — `singularize()` ported into
+  `core/.../table/Inflections.kt`, kotlin-pluralizer + jitpack removed
+  (Phase 2, PR #187).
+- JUnit: **6.1.2** (Java 17 baseline). Test configurations carry
+  `org.gradle.jvm.version = 17` via `TargetJvmVersion` attribute override;
+  published bytecode stays JVM 8 (Phase 2, PR #186).
+- Reflections: **replaced with an internal classpath scanner**; `loadClass`
+  catches only `ClassNotFoundException` + `LinkageError`. `isSubtypeOf` still
+  catches `Throwable` — issue #189 (Phase 2, PRs #185/#188).
+
+Still open:
+
+- Exposed bridge: separate artifact vs code snippets/docs only.
+- Maven Central vs JitPack-only for the first release.

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -34,9 +34,9 @@ State:
 
 - `master` (origin/master @ `3b423c6`) has not been touched in years and is the
   direct ancestor of `develop` (merge-base == master HEAD).
-- `develop` is 54 commits ahead (module split into `core`/`gradle-plugin`,
-  jcenter removal work, MIT license change, etc.) but **never fully tested or
-  released** — this is why master was left behind.
+- `develop` is **56 commits ahead** (module split into `core`/`gradle-plugin`,
+  jcenter removal work, MIT license change, CI-action bumps, etc.) but **never
+  fully tested or released** — this is why master was left behind.
 
 Policy going forward (Git Flow, simplified):
 
@@ -74,6 +74,11 @@ Consequences for the restart:
   fix packaging, plugin application, and publication.
 - These unverified changes are the reason `master` was left behind — do not
   fast-forward `master` until Phase 0 is green and DB tests (Phase 4) pass.
+- **Status (post-Phase 0/2):** the split build is verified — `core` and
+  `gradle-plugin` build, test (72 tests green), and package correctly on Java 25
+  and in CI; `document/` is excluded from the build. Phase 0 also proved the
+  POM/publication config (PR #183) and the Groovy→Kotlin DSL migration. The
+  remaining unverified risk is real-DB behavior, which Phase 4 covers.
 
 ## 4. Phases
 
@@ -138,9 +143,9 @@ the MIT notice.
 
 Status: **landed 2026-08-01.** License headers stripped from all 87 files
 (86 source files + 1 extensionless `META-INF/services/...` registration file;
-PR #180); README badges fixed (PR #181 — MIT URL → opensource.org, bintray
-badge → JitPack). Remaining jcenter reference:
-`document/.../JarmonicaView.kt:61` (doc-string only).
+PR #180, which also added `scripts/strip-license-headers.sh`); README badges
+fixed (PR #181 — MIT URL → opensource.org, bintray badge → JitPack). Remaining
+jcenter reference: `document/.../JarmonicaView.kt:61` (doc-string only).
 
 Original plan (kept for reference):
 
@@ -219,24 +224,25 @@ Outcome: real-DB integration tests live in this repo; runnable locally and in CI
   `integration-test` module or a dedicated source set.
 - Local DBs: install Docker (or use system Postgres/MySQL) and document setup;
   provide `docker-compose.yml` for PostgreSQL/MySQL; SQLite and H2 need no
-  server and are covered by Docker-free embedded-DB tests (see
+  server and **will be covered** by Docker-free embedded-DB tests (see
   [`testing.md`](testing.md)).
 - Tests that need a DB are gated (skip when DB unavailable) so `./gradlew build`
   never fails locally without Docker.
 - CI runs DB-backed tests using Docker services.
-- Decide test framework/tooling (JUnit 5 + Testcontainers preferred).
+- Decide test framework/tooling (**JUnit 6.x** — used in `core`/`gradle-plugin`
+  since Phase 2, PR #186 — plus Testcontainers for PostgreSQL/MySQL).
 
 ### Phase 5 — Issue backlog (quick wins first)
 
 Full triage: [issues-triage.md]. Order:
 
-1. Urgent blockers: #153 (ties into #97). #167 and #162 are resolved — the
-   toolchain/CI fixes landed in Phase 0 (#183); #158, #159 are already closed
-   (verified; not tracked here).
-2. Small: #165 (README/license URLs), #140 (pluralizer), #26 (migration file
-   naming), #47 (prepared statements), #91 (Exposed), #138 (custom columns),
-   #141 (more column types), #145 (alter column), #139 (FK options), #69
-   (query execution API), #4 (created_at/updated_at).
+1. Urgent blockers: #153 (ties into #97). #167, #165, #140, #162 are resolved
+   and closed (toolchain/CI fixes in Phase 0 PR #183; README/license PR #181;
+   pluralizer PR #187); #158, #159 already closed (verified; not tracked here).
+2. Small: #26 (migration file naming), #47 (prepared statements), #91
+   (Exposed), #138 (custom columns), #141 (more column types), #145 (alter
+   column), #139 (FK options), #69 (query execution API), #4
+   (created_at/updated_at), #182 (JitPack badge).
 3. Medium: #7 (closed connection), #85 (SQLite defaults), #67 (timestamp
    default), #80 (Exposed version), #71 (seeding), #97 (JavaExec task tests),
    #155 (programmatic migration docs).

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -43,10 +43,10 @@ Policy going forward (Git Flow, simplified):
 1. `develop` is the integration branch; feature/phase branches are cut from it.
 2. A release branch/tag is created from `develop` only when CI is fully green
    and manual DB tests pass.
-3. The very first milestone of this restart is: make `develop` build green →
-   then fast-forward `master` to `develop` → tag the first new release there.
-   (Because `master` is an ancestor, this is a clean fast-forward, no merge
-   conflict risk.)
+3. The first milestone of this restart is: make `develop` build green and
+   DB-backed tests (Phase 4) pass → then fast-forward `master` to `develop` →
+   tag the first new release there. (Because `master` is an ancestor, this is a
+   clean fast-forward, no merge conflict risk.)
 4. `master` becomes the source of released tags (JitPack builds from tags).
 5. Old branches on the remote (`feature/core_split`, `feature/maven-plugin`,
    `feature/version_up`, `feature/exposed`, `feature/show_sql`, `feature/mit-license`,
@@ -134,7 +134,8 @@ Status: **implemented and merged (2026-08-01, PR #183, merge commit
   JDK 25, `./gradlew build`, dependency-graph submission) + `jvm8-bytecode.yml`
   (javap major-version 52 check) replace `gradle.yml` and `.circleci/config.yml`
   (both deleted). `.github/dependabot.yml` already landed (#169).
-- After green: fast-forward `master` to `develop` (first milestone).
+- After green: fast-forward `master` to `develop` **deferred** — policy is to
+  wait until Phase 4 DB tests pass (see §3.5 and Phase 4).
 
 ### Phase 1 — License header removal
 
@@ -143,9 +144,9 @@ the MIT notice.
 
 Status: **landed 2026-08-01.** License headers stripped from all 87 files
 (86 source files + 1 extensionless `META-INF/services/...` registration file;
-PR #180, which also added `scripts/strip-license-headers.sh`); README badges
-fixed (PR #181 — MIT URL → opensource.org, bintray badge → JitPack). Remaining
-jcenter reference: `document/.../JarmonicaView.kt:61` (doc-string only).
+PR #180; a strip script was drafted but removed before merge (commit
+`5e191b9`); README badges fixed (PR #181 — MIT URL → opensource.org, bintray
+badge → JitPack). Remaining jcenter reference: `document/.../JarmonicaView.kt:61` (doc-string only).
 
 Original plan (kept for reference):
 
@@ -307,6 +308,8 @@ Resolved (2026-08-01):
 - Reflections: **replaced with an internal classpath scanner**; `loadClass`
   catches only `ClassNotFoundException` + `LinkageError`. `isSubtypeOf` still
   catches `Throwable` — issue #189 (Phase 2, PRs #185/#188).
+- Kotlin `jvm` plugin bump 2.3.20 → 2.4.10 (PR #193): **declined** — no
+  functional need; stay on 2.3.20, revisit before the next phase.
 
 Still open:
 

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,0 +1,146 @@
+# Toolchain & Dependency Research
+
+Facts gathered on 2026-08-01. Update this file as versions change.
+
+## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
+
+- Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
+  `./gradlew clean build` is green on Java 25; **72 unit tests pass (68 core,
+  4 gradle-plugin), 0 failures/errors** (Phase 0 baseline was 66; Phase 2 added
+  6 InflectionsTest cases).
+- `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
+  + `java.sourceCompatibility/targetCompatibility = 1.8` in both modules.
+  Verified by `javap`: all main classes are class-file major **52** (JVM 8).
+- `document/` is **dropped from the root build** (`settings.gradle.kts` includes
+  only `core`, `gradle-plugin`). The nested Gradle 4.9 build is untouched.
+- CI replaced: `gradle.yml` + `.circleci/config.yml` → `ci.yml` +
+  `jvm8-bytecode.yml` (see [ci.md](ci.md)).
+
+## JDK / Gradle / Kotlin compatibility
+
+| Component | In repo now | Notes |
+| --- | --- | --- |
+| JDK to run Gradle | OpenJDK 25 | Gradle 9.1.0+ required (Java 25); 9.6.1 in use. |
+| Gradle wrapper | 9.6.1 | `gradle-9.6.1-bin.zip`; wrapper jar/scripts regenerated via `./gradlew wrapper`. |
+| Kotlin | 2.3.20 | `jvmTarget = 1.8` (bytecode) still supported — verified in 2.3.20 with **no** deprecation warning (only the old `kotlinOptions` DSL is deprecated; this build uses `compilerOptions`). |
+| Java language level | 1.8 | `java.sourceCompatibility/targetCompatibility` = 1.8 (no Java sources today). |
+| Test runtime JDK | Java 25 | JVM-8 target proven by the `jvm8-bytecode.yml` javap check (decision, ci.md §3.2), not a JDK-8 run. |
+
+Key references:
+
+- Gradle compatibility matrix: <https://docs.gradle.org/current/userguide/compatibility.html>
+- Gradle 9.1.0 release notes (Java 25 support): <https://docs.gradle.org/9.1.0/release-notes.html>
+- Kotlin 2.3 compatibility guide (drops `-language-version=1.8`; no change to
+  `jvmTarget 1.8`): <https://kotlinlang.org/docs/compatibility-guide-23.html>
+
+## Dependencies
+
+### core
+
+| Dependency | Status | Notes |
+| --- | --- | --- |
+| `org.jetbrains.kotlin:kotlin-test*` | **DONE** | 2.3.20 via `gradle.properties`. |
+| JUnit Jupiter | **DONE** | 5.4.2 → **6.1.2** (Phase 2, PR #186); see the note below on the `TargetJvmVersion` attribute override. |
+| `commons-codec` | **DONE** | 1.15 dropped — unused (PR #184). |
+| `com.github.cesarferreira:kotlin-pluralizer` | **DONE** | removed (PR #187); internal `singularize()` port, see the note below (issue #140 resolved). |
+
+### gradle-plugin
+
+| Dependency | Status | Notes |
+| --- | --- | --- |
+| `kotlin-compiler-embeddable` | **DONE** | 2.3.20. |
+| `kotlin-script-runtime` / `kotlin-script-util` → `kotlin-scripting-jsr223` | **DONE** | `kotlin-script-util` does not exist for 2.3.20 (404; Maven Central metadata frozen at 1.8.22). The JSR-223 engine moved to `kotlin.script.experimental.jsr223`; the plugin's committed `META-INF/services/javax.script.ScriptEngineFactory` was **deleted** (pointed at the removed `org.jetbrains.kotlin.script.jsr223.*` class; the dependency registers its own factory). `AbstractMigrationTask` now uses `javax.script.ScriptEngine` + `getEngineByName("kotlin")`. |
+| `kotlin-reflect` | **DONE** | dropped — only stdlib `KClass` usage (PR #184). |
+| `org.reflections:reflections` | **DONE** | replaced with a classpath scanner in `JarmonicaTaskMain` (Phase 2, PRs #185/#188). |
+| `kotlinx-html-jvm` | **DONE** | dropped here (PR #184); real consumer is `document` (Phase 7). |
+| `kotlin-test` / `kotlin-test-junit5` | **DONE** | pinned to 2.3.20 (were unversioned). |
+| JDBC test drivers (mysql, postgresql, sqlite, mssql) | **DONE** | removed (PR #184); DB drivers move to the Phase 4 integration module. |
+| `com.gradle.plugin-publish` | **DONE** | 0.9.10 → **2.1.1**; legacy `pluginBundle` block removed (2.x moved config into `gradlePlugin`). |
+| `org.jetbrains.dokka` | **DONE** | 0.9.17 → **2.2.0**; removed the removed `outputFormat` DSL. Docs refresh is Phase 7. |
+
+### document (separate subproject, excluded from the root build)
+
+| Dependency | Status | Notes |
+| --- | --- | --- |
+| `kotlinx-html-jvm` | untouched | real consumer; upgrade in Phase 7 or drop the module. |
+| wrapper Gradle 4.9 / version-less Kotlin plugin / `mainClassName` | untouched | not part of the build since Phase 0. |
+
+### Source-code blockers (all resolved in Phase 0)
+
+- `JarmonicaPlugin.kt` — `JavaPluginConvention`/`conventionMapping`/`groovyClosure`
+  removed; tasks created with `tasks.register(name, Class) { task -> ... }`.
+- `HarmonicaPlugin.kt` — legacy `tasks.create(String, Class)` → `tasks.register`.
+- Gradle 9 task validation: `JavaExec` is abstract in Gradle 9, so the
+  Jarmonica task subclasses are `abstract`; every task class carries
+  `@DisableCachingByDefault` (validatePlugins requirement).
+- `Connection.kt:153` — `toUpperCase()` → `uppercase()` (deprecation was an
+  error under Kotlin 2.3).
+
+Still open (not Phase 0):
+
+- `buildConnectionUriFromDbConfig` returns `""` for `Dbms.SQLServer` / `Dbms.H2`;
+  `SqlServerAdapter` is 100% `TODO` (Phase 5).
+- Coordinates/IDs reconciliation (plugin id `harmonica`/`jarmonica` applied vs
+  published; stale `META-INF/gradle-plugins/com.improve_future.harmonica.properties`
+  still bundled) — Phase 6.
+
+## Repositories
+
+- `jcenter()` / `jcenter.bintray.com` — already removed from all build files
+  before Phase 0; the README badges were fixed (#181); the only dead reference
+  left is `document/.../JarmonicaView.kt:61` (doc-string, module excluded from
+  the build).
+- `maven.pkg.jetbrains.space/public/p/kotlinx-html/maven` — **removed from
+  `gradle-plugin` in Phase 0** (kotlinx-html 0.7.3 resolves from Maven Central);
+  still declared in `document/build.gradle` (module excluded from build).
+- `https://jitpack.io` — **removed from both `core` and `gradle-plugin`**
+  (Phase 2, PR #187). Note: while `kotlin-pluralizer` existed, `gradle-plugin`
+  needed jitpack transitively (`api(project(":core"))` exposes it on the
+  runtime classpath) — removal would have failed resolution.
+- `com.github.cesarferreira:kotlin-pluralizer:0.2.9` — **removed** (Phase 2,
+  PR #187). Latest is 1.0.0 (repo dormant since 2023-05-24, not archived).
+  Replaced with an internal `singularize()` port
+  (`core/.../table/Inflections.kt`), behavior-identical (quirks included,
+  e.g. `leaves → leafe`).
+- **JUnit 6.1.2** (Phase 2, PR #186): JUnit 6 has a **Java 17 baseline** and
+  declares `org.gradle.jvm.version = 17` in its Gradle metadata. Our test
+  configurations carry jvm.version 8 (from `targetCompatibility = 1.8`), so
+  resolution initially rejected the artifacts. Fix: override
+  `TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE` to 17 on
+  `testCompileClasspath`/`testRuntimeClasspath` only. **Published (main)
+  bytecode stays JVM 8.** `kotlin-test-junit5:2.3.20` pins junit 5.10.1 /
+  platform 1.10.1; Gradle conflict resolution bumps them to 6.1.2.
+- `org.reflections:0.9.11` — **removed** (Phase 2, PR #185); replaced with a
+  small classpath scanner in `JarmonicaTaskMain` (file + jar protocols).
+  `loadClass` catches only `ClassNotFoundException` + `LinkageError` (PR #188);
+  `isSubtypeOf` still catches `Throwable` — issue #189.
+- `plugins.gradle.org/m2/` (root buildscript) — **gone**; replaced by the
+  `plugins {}` block in root + `pluginManagement` in `settings.gradle.kts`.
+- OSSRH `s01.oss.sonatype.org` (gradle-plugin) — **removed in Phase 0, then
+  restored** (commit `546d956`) as Phase 6 prep; publishing decision open.
+
+## Plugins in `build.gradle.kts` (root)
+
+- `plugins { kotlin("jvm") version "2.3.20" apply false;
+  id("com.gradle.plugin-publish") version "2.1.1" apply false;
+  id("org.jetbrains.dokka") version "2.2.0" apply false }` — legacy
+  `buildscript` + classpath block deleted.
+
+## CI
+
+- `.circleci/config.yml` and `.github/workflows/gradle.yml` **deleted**;
+  replaced by `ci.yml` (PR/push, JDK 25, `./gradlew build`) and
+  `jvm8-bytecode.yml` (asserts class-file major version 52).
+- JVM-8 verification decision: **javap check**, not a JDK-8 toolchain test run
+  (see ci.md §3.2).
+
+## Environment setup (this machine)
+
+- Install standalone `gradle` only if desired; wrapper is sufficient.
+- Install Docker for DB-backed tests (see [testing.md](testing.md)).
+- **Kotlin-daemon flakiness**: on this 2-CPU box, cold `./gradlew` runs
+  occasionally hit Kotlin-daemon incremental-cache errors (`Could not close
+  incremental caches`, `FilePageCache`) and once corrupted a `:core:test`
+  results file — clearing `~/.gradle/kotlin` + daemon caches fixes it. Green
+  but noisy; `ubuntu-latest` CI should be unaffected. Note that `clean` +
+  `--no-daemon` avoids most of it.

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -1,0 +1,99 @@
+# Testing Strategy
+
+## Goals
+
+1. Real-DB integration tests currently live in `KenjiOhtsuka/harmonica_test`
+   → bring them **into this repository**.
+2. Make DB-backed tests runnable locally and in CI.
+3. Never break `./gradlew build` when no database is available.
+
+## Current state
+
+- Unit tests exist in `core` and `gradle-plugin` (JUnit 6.1.2, `useJUnitPlatform`).
+  They use **stubs, not real JDBC drivers**: core's DB tests go through
+  `StubConnection`/`StubDbAdapter`/`StubMigration` (package-private), adapter
+  tests inspect `buildColumnDeclarationForCreateTableSql` by reflection, and
+  `ConnectionTest` only asserts the connection-URI string — **no DBMS is
+  actually exercised by unit tests**.
+- Real-DB tests (`harmonica_test`) require a live PostgreSQL/MySQL with a
+  `developer/developer` user and a `harmonica_test` database; they are a
+  separate Gradle project and only run manually.
+- This machine: no Docker, no local DBMS yet.
+
+## Plan
+
+### 1. Merge `harmonica_test` into this repo
+
+- Create an `integration-test` Gradle subproject (or a dedicated source set in
+  `core`) that contains the real-DB migrations and assertions.
+- Reuse the `core` + `gradle-plugin` code under test directly (same build),
+  which removes the awkwardness of a separate repo publishing snapshots.
+- Port the README instructions from `harmonica_test` into this repo's docs.
+
+### 2. Local DB environments
+
+- Install Docker, then provide `docker-compose.yml` at repo root:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: developer
+      POSTGRES_PASSWORD: developer
+      POSTGRES_DB: harmonica_test
+    ports: ["5432:5432"]
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_USER: developer
+      MYSQL_PASSWORD: developer
+      MYSQL_DATABASE: harmonica_test
+      MYSQL_ROOT_PASSWORD: root
+    ports: ["3306:3306"]
+```
+
+- SQLite needs no server. It is **not** covered by unit tests today (only a URI
+  string is asserted); add a **Docker-free SQLite integration path** that runs
+  in plain CI: `org.xerial:sqlite-jdbc` + a temp-file/`:memory:` DB, gated by
+  the same env-var helper. This gives an always-green real-DB smoke test
+  without Docker.
+- **H2 as the Docker-free alternative**: `Connection.buildConnectionUriFromDbConfig`
+  returns `""` for `Dbms.H2` and `SqlServerAdapter` is 100% TODO. Add H2
+  support as an embedded (no-server) DBMS alongside SQLite; defer SQL Server /
+  Oracle to a later phase (they still require services).
+- Document start/stop and how to run the integration suite against them.
+
+### 3. Gating (DB may be absent)
+
+- Integration tests read connection info from env vars
+  (`HARMONICA_TEST_DB_URL` etc.) or known local defaults.
+- JUnit (6.x): use `@EnabledIfEnvironmentVariable` / an assumption helper so tests
+  **skip** (not fail) when the DB is unreachable.
+- The default `./gradlew build` includes unit tests only; DB tests run via a
+  separate task (e.g. `integrationTest`) or a `-PwithDb` flag.
+
+### 4. CI
+
+- GitHub Actions: run the full suite (including DB tests) using service
+  containers (Postgres/MySQL) so every merge is verified against real DBs.
+- Keep a plain unit-test job as the fast path and as the JDK 8-bytecode check
+  (javap major-version assertion — see [`ci.md`](ci.md)).
+- SQLite/H2 tests run in the fast path (no services needed).
+- Remove/replace the legacy CircleCI config once Actions is authoritative. —
+  **done** (Phase 0).
+
+### 5. Tooling
+
+- Prefer JUnit (6.x, already in use) + Testcontainers (start DB containers from
+  within tests) once Docker is available; env-var-based config remains the fallback.
+- Migrate existing `harmonica_test` assertions (they are currently shell-style:
+  `./gradlew jarmonicaUp` then inspect the DB) into proper assertions.
+
+## Definition of done
+
+- `integration-test` module exists in this repo, ported from `harmonica_test`.
+- `docker-compose.yml` + docs committed; local run verified on this machine.
+- `./gradlew build` passes without Docker; `integrationTest` passes with Docker.
+- SQLite + H2 real-DB smoke tests are part of the always-on fast path.
+- CI job runs DB-backed tests on every push.

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -37,14 +37,14 @@
 ```yaml
 services:
   postgres:
-    image: postgres:16
+    image: postgres:16.14
     environment:
       POSTGRES_USER: developer
       POSTGRES_PASSWORD: developer
       POSTGRES_DB: harmonica_test
     ports: ["5432:5432"]
   mysql:
-    image: mysql:8
+    image: mysql:8.4.11
     environment:
       MYSQL_USER: developer
       MYSQL_PASSWORD: developer
@@ -70,6 +70,9 @@ services:
   (`HARMONICA_TEST_DB_URL` etc.) or known local defaults.
 - JUnit (6.x): use `@EnabledIfEnvironmentVariable` / an assumption helper so tests
   **skip** (not fail) when the DB is unreachable.
+- Add a short-timeout **connectivity probe** (e.g. open the JDBC connection
+  with a 1–2 s connect timeout in a `@BeforeAll`; on failure, `Assumptions.abort`)
+  so a down/absent DB **skips** the suite instead of failing it.
 - The default `./gradlew build` includes unit tests only; DB tests run via a
   separate task (e.g. `integrationTest`) or a `-PwithDb` flag.
 


### PR DESCRIPTION
Adds the planning/support layer for the restart and reconciles it with current reality.

## What's in here

- **`spec/`** — the planning docs referenced by `AGENTS.md` but never committed to the repo:
  `plan.md` (master plan), `tech-notes.md` (toolchain/dependency research), `issues-triage.md`,
  `ci.md`, `testing.md`, `exposed-integration.md`, `README.md`.
- **`.opencode/`** — opencode agents (`spec-review`, `build-review`, `exposed-review`),
  commands (`review-specs`), and skills (`harmonica-dev`, new `plan-review`).
- **`AGENTS.md`** — agent guidance for this repo.

## Plan review (run after Phase 2 merged)

Reconciled the docs against the actual repo and verified with the `spec-review` agent:

- Phase 2 marked **merged** (PRs #184–#188); authoritative test count **72** (68 core + 4 plugin).
- Phase 3 marked **not started — next phase**.
- `tech-notes.md` dependency rows flipped to DONE with PR refs.
- `issues-triage.md` re-snapshotted: 30 open issues; #167/#162/#165/#140/#182/#163 noted resolved/closed.
- `ci.md` updated for `actions/checkout@v7` (PR #170), closed Dependabot PRs #171/#172/#178.
- `testing.md` updated to JUnit 6.1.2.
- `exposed-integration.md` open question #3 de-flagged as "resolved" (still open).

Also closes (per plan review): #167, #165, #140.

Docs-only + opencode config; no code/build changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for development workflows, toolchain requirements, CI, testing, dependency management, issue triage, and release planning.
  * Documented optional database integration, migration considerations, repository risks, and future development phases.
* **New Features**
  * Added automated review support for specifications, builds, and integration plans.
  * Added a command to reconcile planning documents with the current project state.
* **Chores**
  * Updated repository exclusions for local tooling dependencies.
  * Prevented documentation and local tooling changes from unnecessarily triggering CI workflows.
  * Disabled automatic code reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->