### PR TITLE
Phase 3: remove dead hasExposed flag, expose jdbcConnection

### DIFF
--- a/core/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
+++ b/core/src/main/kotlin/com/improve_future/harmonica/core/Connection.kt
@@ -4,7 +4,7 @@ import java.io.Closeable
 import java.sql.*
 
 open class Connection(
-    override val config: DbConfig, protected val hasExposed: Boolean
+    override val config: DbConfig
 ) : Closeable, ConnectionInterface {
     private lateinit var coreConnection: java.sql.Connection
 
@@ -30,12 +30,11 @@ open class Connection(
         get() {
             if (isClosed) connect(config)
 
-            return if (hasExposed)
-                coreConnection
-//            TransactionManager.current().connection
-            else
-                coreConnection
+            return coreConnection
         }
+
+    override val jdbcConnection: java.sql.Connection
+        get() = coreConnection
 
     private var database: Database? = null
 
@@ -72,8 +71,8 @@ open class Connection(
     }
 
     companion object {
-        fun create(hasExposed: Boolean, block: DbConfig.() -> Unit): Connection {
-            return Connection(DbConfig.create(block), hasExposed)
+        fun create(block: DbConfig.() -> Unit): Connection {
+            return Connection(DbConfig.create(block))
         }
 
         private fun buildConnectionUriFromDbConfig(dbConfig: DbConfig): String {

--- a/core/src/main/kotlin/com/improve_future/harmonica/core/ConnectionInterface.kt
+++ b/core/src/main/kotlin/com/improve_future/harmonica/core/ConnectionInterface.kt
@@ -4,6 +4,7 @@ import java.sql.Statement
 
 interface ConnectionInterface {
     val config: DbConfig
+    val jdbcConnection: java.sql.Connection
     fun transaction(block: Connection.() -> Unit)
     fun execute(sql: String): Boolean
     fun doesTableExist(tableName: String): Boolean

--- a/core/src/main/kotlin/com/improve_future/harmonica/core/table/column/BigIntegerColumn.kt
+++ b/core/src/main/kotlin/com/improve_future/harmonica/core/table/column/BigIntegerColumn.kt
@@ -1,7 +1,7 @@
 package com.improve_future.harmonica.core.table.column
 
-// Exposed take a Long type as BigInteger in database, actually BigInteger can be bigger than Long
-// but for now we limit it to the size of a Long
+// A database BigInteger can be bigger than Long, but for now we limit it to the
+// size of a Long
 internal class BigIntegerColumn(name: String) : AbstractColumn(name) {
     override var sqlDefault: String? = null
 

--- a/core/src/test/kotlin/com/improve_future/harmonica/stub/core/StubConnection.kt
+++ b/core/src/test/kotlin/com/improve_future/harmonica/stub/core/StubConnection.kt
@@ -10,6 +10,13 @@ class StubConnection : ConnectionInterface {
 
     val executedSqlList = mutableListOf<String>()
 
+    @Deprecated(
+        "Cause Error",
+        ReplaceWith("Can't be replaced. It's created only to meet interface.")
+    )
+    override val jdbcConnection: java.sql.Connection
+        get() = throw UnsupportedOperationException()
+
     override fun transaction(block: Connection.() -> Unit) {
 
     }

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/config/PluginConfig.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/config/PluginConfig.kt
@@ -2,18 +2,4 @@ package com.improve_future.harmonica.config
 
 internal object PluginConfig {
     const val groupName = "migration"
-
-    fun hasExposed(): Boolean {
-        return try {
-            null != Class.forName("org.jetbrains.exposed.sql.Database")
-        } catch (e: Exception) {
-            false
-        }
-    }
-
-//    object Exposed {
-//        fun getTransactionManager(): Class<*> {
-//            return Class.forName("org.jetbrains.exposed.sql.transactions.TransactionManager")
-//        }
-//    }
 }

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractMigrationTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractMigrationTask.kt
@@ -1,6 +1,5 @@
 package com.improve_future.harmonica.plugin
 
-import com.improve_future.harmonica.config.PluginConfig
 import com.improve_future.harmonica.core.*
 import org.gradle.api.tasks.Input
 import org.gradle.work.DisableCachingByDefault
@@ -27,7 +26,7 @@ abstract class AbstractMigrationTask : AbstractTask() {
     }
 
     protected fun createConnection(): Connection {
-        return Connection(loadConfigFile(), PluginConfig.hasExposed())
+        return Connection(loadConfigFile())
     }
 
     protected companion object {

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/task/JarmonicaTaskMain.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/task/JarmonicaTaskMain.kt
@@ -1,6 +1,5 @@
 package com.improve_future.harmonica.task
 
-import com.improve_future.harmonica.config.PluginConfig
 import com.improve_future.harmonica.core.AbstractMigration
 import com.improve_future.harmonica.core.Connection
 import com.improve_future.harmonica.core.DbConfig
@@ -23,7 +22,7 @@ abstract class JarmonicaTaskMain {
     protected fun createConnection(
         packageName: String, env: String
     ): Connection {
-        return Connection(loadDbConfig(packageName, env), PluginConfig.hasExposed())
+        return Connection(loadDbConfig(packageName, env))
     }
 
     protected fun findMigrationClassList(packageName: String): List<Class<out AbstractMigration>> {

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -1,7 +1,7 @@
 # Exposed Optionality — Design
 
-> **Status: design only (Phase 3, not started).** `harmonica-exposed` does not
-> exist yet and `exposedTransaction` is a proposed **future** API. Nothing in
+> **Status: design agreed; development started 2026-08-08.** `harmonica-exposed`
+> does not exist yet and `exposedTransaction` is a proposed **future** API. Nothing in
 > this document is shipped or supported until the artifact, the script-classpath
 > handling, transaction tests, and real-DB verification land in Phase 3. Issue
 > #91 stays open until then.
@@ -20,18 +20,19 @@ migrations. Consequences:
 
 ## Current state (from the code)
 
-- `core` has **no Exposed dependency** — good.
-- `core/.../Connection.kt` still carries a `hasExposed: Boolean` constructor
-  flag whose ternary returns the same value in both branches (dead code), plus
-  a commented-out `TransactionManager.current().connection`.
-- `gradle-plugin/.../PluginConfig.kt` detects Exposed at runtime via
-  `Class.forName("org.jetbrains.exposed.sql.Database")` — this is the right
-  *technique* (no compile-time reference), but the flag is not actually used
-  anywhere meaningful.
+- `core` has **no Exposed dependency** — good. The dead `hasExposed` flag on
+  `Connection` was removed (Phase 3, PR A): `Connection` no longer carries it
+  and `Connection.create` no longer takes it.
+- `ConnectionInterface` exposes **`jdbcConnection`** (raw
+  `java.sql.Connection`, no silent reconnect) — added in PR A so the bridge can
+  reach the underlying connection.
+- `gradle-plugin` no longer special-cases Exposed: `PluginConfig.hasExposed()`
+  (the `Class.forName` runtime detection) was **deleted** in PR A. Plugin
+  behavior is identical with or without Exposed on the classpath.
 - **Bridge contract**: the bridge targets a **single supported Exposed major**:
-  **Exposed 0.x** — the major whose JDBC API lives in package
+  **Exposed 0.x — pinned 0.61.0** — the major whose JDBC API lives in package
   `org.jetbrains.exposed.sql` (`Database.connect(DataSource)` +
-  `transaction()`), matching the runtime detection string in `PluginConfig.kt`.
+  `transaction()`).
   Exposed 1.x moved these classes to `org.jetbrains.exposed.v1.jdbc.*`, so
   adopting 1.x requires updating the detection class name and bridge APIs
   together; never support two majors in one bridge.
@@ -95,15 +96,16 @@ which commits, and on failure rolls back **and closes** the connection
 on success; on failure a double-rollback plus a stale Exposed `Database`
 pointing at the closed connection).
 
-Decide **one owner** (open question #3):
+Decide **one owner** — **resolved (2026-08-08): Option A, harmonica owns the
+transaction.**
 
-- **Option A (recommended): harmonica owns the transaction.** The bridge binds
+- **Option A (chosen): harmonica owns the transaction.** The bridge binds
   harmonica's connection into Exposed's manager and runs the Exposed DSL
   *without* an Exposed-managed commit (i.e. `TransactionManager`/stack-based
   registration, or `transaction(db){}` where the commit is a no-op because the
   outer `Connection.transaction` commits). Users write the Exposed DSL; harmonica
   does commit/rollback/close.
-- **Option B: Exposed owns the transaction.** Then the harmonica runner must
+- **Option B (rejected): Exposed owns the transaction.** Then the harmonica runner must
   NOT wrap migrations in `Connection.transaction` when the bridge is used
   (require an explicit opt-in), and harmonica's `Connection.transaction` is
   bypassed.
@@ -185,9 +187,16 @@ class M20260801_Migrate : AbstractMigration() {
 
 ## Open questions
 
-- Publish `harmonica-exposed` as a separate artifact, or start with a
-  documented snippet and promote to an artifact later?
-- Exact Exposed **0.x** version to use in the bridge (match user expectations;
-  keep it a normal version range within the 0.x line).
-- Whether `exposedTransaction` should manage commit/rollback or delegate to
-  `Connection.transaction`.
+Resolved (2026-08-08):
+
+- **Separate artifact** — ship `harmonica-exposed` as a Gradle module, not a
+  snippet first.
+- **Exposed 0.61.0** — latest 0.x, JDBC API in `org.jetbrains.exposed.sql`.
+- **Option A** — harmonica owns the transaction (no Exposed-managed commit).
+
+Remaining:
+
+- `exposedTransaction` commit/rollback detail under Option A: whether it needs
+  a no-op-commit wrapper or plain `transaction(db){}` is safe because the outer
+  `Connection.transaction` commits (verify empirically in Phase 3).
+- Script classpath wiring for `.kts` migrations (Pitfall F).

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -204,7 +204,9 @@ gradle-plugin; Phase 0 baseline was 66).
 Outcome: `core` has zero Exposed references; users decide whether to use
 Exposed, and integration is documented. Full design: [exposed-integration.md].
 
-Status: **not started — next phase.**
+Status: **in progress (decisions resolved 2026-08-08).** Plan: ship
+`harmonica-exposed` as a separate module pinned to Exposed 0.61.0; Option A
+transaction ownership (harmonica owns).
 
 - Remove dead `hasExposed` flag plumbing from `Connection.kt` (currently a
   no-op ternary).
@@ -313,5 +315,14 @@ Resolved (2026-08-01):
 
 Still open:
 
-- Exposed bridge: separate artifact vs code snippets/docs only.
 - Maven Central vs JitPack-only for the first release.
+
+Resolved for Phase 3 (2026-08-08):
+
+- Exposed bridge artifact: **ship as a separate Gradle module** (`exposed/`,
+  artifact `harmonica-exposed`), not snippet-first.
+- Bridge targets **Exposed 0.61.0** (latest 0.x; JDBC API in
+  `org.jetbrains.exposed.sql`).
+- Transaction ownership: **Option A — harmonica owns the transaction** (bridge
+  binds harmonica's connection into Exposed's manager; no Exposed-managed
+  commit).


### PR DESCRIPTION
Part of Phase 3 (Exposed optionality), per spec/plan.md §4 and spec/exposed-integration.md §1.

- `core` `Connection` no longer takes the dead `hasExposed` flag (both ternary branches returned the same value); `Connection.create` drops the parameter.
- `ConnectionInterface` gains `val jdbcConnection: java.sql.Connection` returning the raw connection without triggering the silent reconnect path (won't mask issue #7).
- `gradle-plugin`: `PluginConfig.hasExposed()` (runtime `Class.forName` detection) deleted; both call sites updated. Plugin behavior now identical with or without Exposed.
- `core` BigIntegerColumn comment reworded (no Exposed knowledge left in core).
- Specs updated: Phase 3 status, resolved decisions (separate artifact, Exposed 0.61.0, Option A transaction ownership), current-state section refreshed.

Build green locally (72 tests). Decision details: spec/exposed-integration.md §2.1 (Option A).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed the underlying JDBC connection through the connection interface.
  * Simplified connection creation by removing the need for an additional integration flag.

* **Documentation**
  * Updated integration plans and design documentation for the Exposed bridge, including versioning and transaction ownership decisions.
  * Clarified database column limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->