### PR TITLE
Phase 3: add harmonica-exposed bridge module (exposedTransaction)

### DIFF
--- a/.github/workflows/jvm8-bytecode.yml
+++ b/.github/workflows/jvm8-bytecode.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Assert JVM 8 bytecode
         run: |
           set -euo pipefail
-          for dir in core/build/classes/kotlin/main gradle-plugin/build/classes/kotlin/main; do
+          for dir in core/build/classes/kotlin/main exposed/build/classes/kotlin/main gradle-plugin/build/classes/kotlin/main; do
             [ -d "$dir" ] || { echo "missing Kotlin output directory: $dir"; exit 1; }
             classfiles=$(find "$dir" -name '*.class' | sort)
             [ -n "$classfiles" ] || { echo "no class files found in $dir"; exit 1; }

--- a/core/src/test/kotlin/com/improve_future/harmonica/stub/core/StubConnection.kt
+++ b/core/src/test/kotlin/com/improve_future/harmonica/stub/core/StubConnection.kt
@@ -10,12 +10,9 @@ class StubConnection : ConnectionInterface {
 
     val executedSqlList = mutableListOf<String>()
 
-    @Deprecated(
-        "Cause Error",
-        ReplaceWith("Can't be replaced. It's created only to meet interface.")
-    )
+    @Deprecated("StubConnection does not provide a JDBC connection")
     override val jdbcConnection: java.sql.Connection
-        get() = throw UnsupportedOperationException()
+        get() = throw UnsupportedOperationException("StubConnection does not provide a JDBC connection")
 
     override fun transaction(block: Connection.() -> Unit) {
 

--- a/exposed/build.gradle.kts
+++ b/exposed/build.gradle.kts
@@ -1,0 +1,58 @@
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("jvm")
+    id("maven-publish")
+    id("org.jetbrains.dokka")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api(project(":core"))
+    api("org.jetbrains.exposed:exposed-jdbc:0.61.0")
+
+    // Tests
+    testImplementation("org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.2")
+    testImplementation("org.xerial:sqlite-jdbc:3.45.3.0")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+// JUnit 6 requires Java 17+, but published bytecode must stay JVM 8
+// (jvmTarget = JVM_1_8 above). The Gradle metadata of JUnit 6 artifacts
+// declares org.gradle.jvm.version = 17, while these configurations carry
+// 8 from targetCompatibility, which would reject the dependency. Override
+// the attribute on the test classpaths only so resolution succeeds and
+// tests run on the installed JDK (25), which satisfies the 17+ baseline.
+configurations {
+    testCompileClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+}

--- a/exposed/src/main/kotlin/com/improve_future/harmonica/exposed/ExposedMigration.kt
+++ b/exposed/src/main/kotlin/com/improve_future/harmonica/exposed/ExposedMigration.kt
@@ -1,0 +1,42 @@
+package com.improve_future.harmonica.exposed
+
+import com.improve_future.harmonica.core.AbstractMigration
+import com.improve_future.harmonica.core.Connection
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.lang.ref.WeakReference
+import java.lang.reflect.Proxy
+import java.util.WeakHashMap
+
+private val databaseCache = WeakHashMap<Connection, Database>()
+
+fun AbstractMigration.exposedTransaction(block: Transaction.() -> Unit) {
+    val connection = connection as? Connection
+        ?: error("exposedTransaction requires a com.improve_future.harmonica.core.Connection")
+    transaction(connection.exposedDatabase()) { block() }
+}
+
+private fun Connection.exposedDatabase(): Database =
+    databaseCache.getOrPut(this) {
+        val weakConnection = WeakReference(this)
+        Database.connect(
+            getNewConnection = { weakConnection.exposedConnection() },
+            databaseConfig = DatabaseConfig { defaultMaxAttempts = 1 }
+        )
+    }
+
+private fun WeakReference<Connection>.exposedConnection(): java.sql.Connection {
+    val connection = get()
+        ?: error("harmonica Connection was garbage-collected while Exposed was in use")
+    return Proxy.newProxyInstance(
+        java.sql.Connection::class.java.classLoader,
+        arrayOf(java.sql.Connection::class.java)
+    ) { _, method, args ->
+        when (method.name) {
+            "commit", "rollback", "close" -> null
+            else -> method.invoke(connection.jdbcConnection, *(args ?: emptyArray()))
+        }
+    } as java.sql.Connection
+}

--- a/exposed/src/main/kotlin/com/improve_future/harmonica/exposed/ExposedMigration.kt
+++ b/exposed/src/main/kotlin/com/improve_future/harmonica/exposed/ExposedMigration.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.DatabaseConfig
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.lang.ref.WeakReference
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Proxy
 import java.util.WeakHashMap
 
@@ -36,7 +37,11 @@ private fun WeakReference<Connection>.exposedConnection(): java.sql.Connection {
     ) { _, method, args ->
         when (method.name) {
             "commit", "rollback", "close" -> null
-            else -> method.invoke(connection.jdbcConnection, *(args ?: emptyArray()))
+            else -> try {
+                method.invoke(connection.jdbcConnection, *(args ?: emptyArray()))
+            } catch (e: InvocationTargetException) {
+                throw e.targetException
+            }
         }
     } as java.sql.Connection
 }

--- a/exposed/src/test/kotlin/com/improve_future/harmonica/exposed/ExposedMigrationTest.kt
+++ b/exposed/src/test/kotlin/com/improve_future/harmonica/exposed/ExposedMigrationTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.insert
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
+import java.sql.SQLException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -32,6 +33,14 @@ private class FailingMigration : AbstractMigration() {
         exposedTransaction {
             SchemaUtils.create(Users)
             error("boom")
+        }
+    }
+}
+
+private class InvalidSqlMigration : AbstractMigration() {
+    override fun up() {
+        exposedTransaction {
+            exec("THIS IS NOT SQL")
         }
     }
 }
@@ -107,6 +116,19 @@ class ExposedMigrationTest {
         }
         assertTrue(connection.doesTableExist("users_exposed"))
         assertEquals(1, connection.rowCount("users_exposed"))
+        connection.close()
+    }
+
+    @Test
+    fun testSqlExceptionPropagatesThroughProxyAsSqlException() {
+        val connection = createConnection("sqlerror")
+        val migration = InvalidSqlMigration()
+        migration.connection = connection
+        assertFailsWith<SQLException> {
+            connection.transaction {
+                migration.up()
+            }
+        }
         connection.close()
     }
 }

--- a/exposed/src/test/kotlin/com/improve_future/harmonica/exposed/ExposedMigrationTest.kt
+++ b/exposed/src/test/kotlin/com/improve_future/harmonica/exposed/ExposedMigrationTest.kt
@@ -1,0 +1,88 @@
+package com.improve_future.harmonica.exposed
+
+import com.improve_future.harmonica.core.AbstractMigration
+import com.improve_future.harmonica.core.Connection
+import com.improve_future.harmonica.core.Dbms
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+private object Users : Table("users_exposed") {
+    val name = varchar("name", 100)
+}
+
+private class CreateAndInsertMigration : AbstractMigration() {
+    override fun up() {
+        exposedTransaction {
+            SchemaUtils.create(Users)
+            Users.insert { it[name] = "test-user" }
+        }
+    }
+}
+
+private class FailingMigration : AbstractMigration() {
+    override fun up() {
+        exposedTransaction {
+            SchemaUtils.create(Users)
+            error("boom")
+        }
+    }
+}
+
+class ExposedMigrationTest {
+    private fun createConnection(name: String): Connection {
+        val dbPath = Path.of("build", "test-db", name)
+        Files.createDirectories(dbPath.parent)
+        for (suffix in listOf(".db", ".db-wal", ".db-shm")) {
+            Files.deleteIfExists(Path.of(dbPath.toString() + suffix))
+        }
+        return Connection.create {
+            dbms = Dbms.SQLite
+            dbName = dbPath.toString()
+            user = ""
+            password = ""
+        }
+    }
+
+    private fun Connection.rowCount(tableName: String): Int {
+        createStatement().use { statement ->
+            statement.executeQuery("SELECT COUNT(*) FROM $tableName").use { rs ->
+                rs.next()
+                return rs.getInt(1)
+            }
+        }
+    }
+
+    @Test
+    fun testExposedDslRunsInsideHarmonicaTransaction() {
+        val connection = createConnection("success")
+        val migration = CreateAndInsertMigration()
+        migration.connection = connection
+        connection.transaction {
+            migration.up()
+        }
+        assertTrue(connection.doesTableExist("users_exposed"))
+        assertEquals(1, connection.rowCount("users_exposed"))
+        connection.close()
+    }
+
+    @Test
+    fun testExposedDslRollsBackWithHarmonicaOnFailure() {
+        val connection = createConnection("rollback")
+        val migration = FailingMigration()
+        migration.connection = connection
+        assertFailsWith<IllegalStateException> {
+            connection.transaction {
+                migration.up()
+            }
+        }
+        assertTrue(!connection.doesTableExist("users_exposed"))
+        connection.close()
+    }
+}

--- a/exposed/src/test/kotlin/com/improve_future/harmonica/exposed/ExposedMigrationTest.kt
+++ b/exposed/src/test/kotlin/com/improve_future/harmonica/exposed/ExposedMigrationTest.kt
@@ -28,6 +28,7 @@ private class CreateAndInsertMigration : AbstractMigration() {
 
 private class FailingMigration : AbstractMigration() {
     override fun up() {
+        createTable("harmonica_rollback_probe") { integer("probe") }
         exposedTransaction {
             SchemaUtils.create(Users)
             error("boom")
@@ -69,6 +70,8 @@ class ExposedMigrationTest {
         }
         assertTrue(connection.doesTableExist("users_exposed"))
         assertEquals(1, connection.rowCount("users_exposed"))
+        assertTrue(!connection.jdbcConnection.isClosed)
+        assertTrue(!connection.jdbcConnection.autoCommit)
         connection.close()
     }
 
@@ -83,6 +86,27 @@ class ExposedMigrationTest {
             }
         }
         assertTrue(!connection.doesTableExist("users_exposed"))
+        assertTrue(!connection.doesTableExist("harmonica_rollback_probe"))
+        connection.close()
+    }
+
+    @Test
+    fun testExposedDslSurvivesHarmonicaReconnect() {
+        val connection = createConnection("reconnect")
+        val failing = FailingMigration()
+        failing.connection = connection
+        assertFailsWith<IllegalStateException> {
+            connection.transaction {
+                failing.up()
+            }
+        }
+        val ok = CreateAndInsertMigration()
+        ok.connection = connection
+        connection.transaction {
+            ok.up()
+        }
+        assertTrue(connection.doesTableExist("users_exposed"))
+        assertEquals(1, connection.rowCount("users_exposed"))
         connection.close()
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,4 +6,4 @@ pluginManagement {
 }
 
 rootProject.name = "harmonica"
-include("core", "gradle-plugin")
+include("core", "exposed", "gradle-plugin")

--- a/spec/README.md
+++ b/spec/README.md
@@ -28,8 +28,8 @@ plan to restart and modernize the project.
   `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
   `actions/setup-java@5.6.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (Dependabot). CircleCI removed.
-- Three active modules: `core`, `exposed`, `gradle-plugin` — **74 tests green**
-  (68 core + 4 plugin + 2 exposed); `document` (nested standalone build) is
+- Three active modules: `core`, `exposed`, `gradle-plugin` — **75 tests green**
+  (68 core + 4 plugin + 3 exposed); `document` (nested standalone build) is
   excluded from the build
 - License headers stripped from all source files (PR #180); README badges fixed
   (PR #181)

--- a/spec/README.md
+++ b/spec/README.md
@@ -28,8 +28,8 @@ plan to restart and modernize the project.
   `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
   `actions/setup-java@5.6.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (Dependabot). CircleCI removed.
-- Three active modules: `core`, `exposed`, `gradle-plugin` — **75 tests green**
-  (68 core + 4 plugin + 3 exposed); `document` (nested standalone build) is
+- Three active modules: `core`, `exposed`, `gradle-plugin` — **76 tests green**
+  (68 core + 4 plugin + 4 exposed); `document` (nested standalone build) is
   excluded from the build
 - License headers stripped from all source files (PR #180); README badges fixed
   (PR #181)

--- a/spec/README.md
+++ b/spec/README.md
@@ -28,13 +28,16 @@ plan to restart and modernize the project.
   `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
   `actions/setup-java@5.6.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (Dependabot). CircleCI removed.
-- Two active modules: `core`, `gradle-plugin` — **72 tests green** (68 core +
-  4 plugin); `document` (nested standalone build) is excluded from the build
+- Three active modules: `core`, `exposed`, `gradle-plugin` — **74 tests green**
+  (68 core + 4 plugin + 2 exposed); `document` (nested standalone build) is
+  excluded from the build
 - License headers stripped from all source files (PR #180); README badges fixed
   (PR #181)
-- No Exposed dependency in `core` (runtime reflection detection remains in
-  `gradle-plugin`; a real Exposed bridge is a **future Phase 3** design, see
-  [`exposed-integration.md`](exposed-integration.md))
+- No Exposed dependency in `core`. The optional `harmonica-exposed` module
+  (`exposed/`, pinned to Exposed 0.61.0) ships the `exposedTransaction` bridge
+  (Phase 3, PR B); runtime reflection detection was removed from
+  `gradle-plugin` (PR A) — see
+  [`exposed-integration.md`](exposed-integration.md)
 - Tests for real DBMS still live in the separate `harmonica_test` repository —
   to be merged in Phase 4
 - **`develop` is 56 commits ahead of `master`** — Phase 4 (real-DB tests) must

--- a/spec/ci.md
+++ b/spec/ci.md
@@ -72,9 +72,9 @@ Since Gradle 9 cannot run on JDK 8:
 
 - After `./gradlew build`, runs `javap -verbose` on **every `.class` file** in
   each module's Kotlin main output directory (`core/.../kotlin/main`,
-  `gradle-plugin/.../kotlin/main`) and asserts **class-file major version 52**
-  (JDK 8) for all of them. Major version → Java mapping: 52=Java 8, 61=17,
-  69=25.
+  `exposed/.../kotlin/main`, `gradle-plugin/.../kotlin/main`) and asserts
+  **class-file major version 52** (JDK 8) for all of them. Major version →
+  Java mapping: 52=Java 8, 61=17, 69=25.
 - **Phase 0 sub-decision (resolved)**: keep the lightweight javap check. The
   alternative — running the test suite on a JDK 8 runtime via Gradle toolchains
   (foojay-resolver-convention + `JavaLanguageVersion.of(8)`) — adds a toolchain
@@ -119,7 +119,7 @@ updates:
     open-pull-requests-limit: 5
 ```
 
-- `directory: "/"` scans the whole multi-module build (`core`,
+- `directory: "/"` scans the whole multi-module build (`core`, `exposed`,
   `gradle-plugin`; `document` is excluded from the build) including the Gradle
   wrapper and `gradle.properties`.
 - **No grouping** — keeps each dependency bump its own small PR, matching the

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -3,7 +3,7 @@
 > **Status: shipped in part (2026-08-09, PR B).** The `exposed/` module
 > (artifact `harmonica-exposed`), the `exposedTransaction` bridge, and embedded
 > SQLite transaction tests (commit + rollback paths) exist and pass
-> (`./gradlew :exposed:test`, 2 tests). Still open in Phase 3: script-classpath
+> (`./gradlew :exposed:test`, 3 tests). Still open in Phase 3: script-classpath
 > wiring for `.kts` migrations (Pitfall F) and a demo project. Issue #91 stays
 > open until the whole flow ships.
 
@@ -111,7 +111,7 @@ fun AbstractMigration.exposedTransaction(block: Transaction.() -> Unit) {
 The migration runner already wraps `up()`/`down()` in
 `Connection.transaction` (`MigrationUpTask.kt:21-27`, `JarmonicaUpMain.kt:27-34`),
 which commits, and on failure rolls back **and closes** the connection
-(`Connection.kt:107-117`). Running Exposed's own `transaction(db){}` on the
+(`Connection.kt:106-117`). Running Exposed's own `transaction(db){}` on the
 **same physical connection** produces a nested commit/rollback pair (harmless
 on success; on failure a double-rollback plus a stale Exposed `Database`
 pointing at the closed connection).
@@ -144,12 +144,14 @@ transaction.**
   override is still needed at all.
 - **Reconnect invalidation (resolved in PR B)**: harmonica reconnects a closed
   connection lazily (`Connection.kt:29-38`). The bridge proxy resolves
-  `jdbcConnection` **on every method call**, so after a reconnect it
-  automatically targets the fresh connection. The cache is keyed by the
-  `Connection` instance, so a *new* `Connection` (e.g. a new migration run)
-  gets its own `Database`. The rollback test exercises this: after the failed
-  transaction closes the connection, `doesTableExist` reconnects and the Exposed
-  registration still resolves.
+  `jdbcConnection` **on every method call**, so once a reconnect has been
+  triggered by any core call, Exposed automatically targets the fresh
+  connection. The cache is keyed by the `Connection` instance, so a *new*
+  `Connection` (e.g. a new migration run) gets its own `Database`.
+  `testExposedDslSurvivesHarmonicaReconnect` proves this end-to-end: a failed
+  migration closes the connection, then a second `exposedTransaction` on the
+  same `Connection` creates + inserts successfully through the reconnected
+  connection.
 - **Single-threaded assumption**: the cached `Database` wraps one connection and
   is reused for every Exposed transaction; it is not thread-safe. The migration
   runner is single-threaded, so this holds. The `WeakHashMap` cache is likewise
@@ -166,6 +168,24 @@ transaction.**
 - **Name collision**: `core` has an (empty) `com.improve_future.harmonica.core.Database`
   class (`Database.kt`). Avoid wildcard imports in the bridge so it doesn't
   collide with `org.jetbrains.exposed.sql.Database`.
+- **`setReadOnly` is delegated**: Exposed 0.61's transaction setup calls
+  `setTransactionIsolation(...)` (already no-op'd for non-SQLite by core's proxy)
+  **and** `setReadOnly(false)` on the wrapped connection. `setReadOnly` is *not*
+  overridden anywhere, so for PostgreSQL/MySQL it executes driver-side state
+  changes on the open transaction. Deferred to the Phase 4 real-DB work.
+- **Exposed's global registry grows in long-lived JVMs (known limitation)**: 
+  `Database.connect` registers every `Database` in Exposed's global
+  `TransactionManager` (`ConcurrentHashMap` + `ConcurrentLinkedDeque`) for the
+  JVM lifetime, and the bridge never calls `closeAndUnregister` (core purity
+  forbids a close hook). The bridge's own `WeakHashMap` cache evicts correctly,
+  but each distinct `Connection` (e.g. each migration run inside a Gradle
+  daemon) leaves one permanently-registered `Database` whose connector holds a
+  dead `WeakReference`. Bounded per run, unbounded over a long-lived JVM.
+  Acceptable for a migration tool (short-lived task JVMs); revisit if harmonica
+  gains a long-lived server mode. Note also that a new `Database.connect`
+  overwrites Exposed's *global default* manager, so a bare `transaction {}` in
+  user code afterwards routes to the bridge's proxy-backed `Database` —
+  harmless for harmonica's flow.
 - **Script classpath (Pitfall F)**: migration `.kts` files are evaluated by the
   Gradle plugin's JSR-223 engine on the **plugin's classpath**
   (`AbstractMigrationTask.kt:33-37`). Adding `harmonica-exposed` via the user's
@@ -218,9 +238,13 @@ class M20260801_Migrate : AbstractMigration() {
 
 **Shipped in PR B (2026-08-09):** the `exposed/` module builds with
 `exposed-jdbc:0.61.0`; `exposedTransaction` runs the Exposed DSL inside
-harmonica's `Connection.transaction` (Option A) with commit + rollback proven by
-SQLite tests (`:exposed:test`); full `./gradlew build` is green with and without
-Exposed on the classpath; `:core` still has zero Exposed references.
+harmonica's `Connection.transaction` (Option A) proven by three SQLite tests
+(`:exposed:test`): commit (DDL+insert persist; Exposed did not close the
+connection or restore autoCommit), rollback (harmonica DSL + Exposed DSL in one
+migration both rolled back — one shared transaction), and reconnect (a second
+`exposedTransaction` succeeds through harmonica's reconnected connection). Full
+`./gradlew build` is green with and without Exposed on the classpath; `:core`
+still has zero Exposed references.
 
 **Remaining for Phase 3:** script-classpath wiring for `.kts` migrations
 (Pitfall F) and the demo project against a real DB (SQLite here; PostgreSQL/MySQL

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -1,10 +1,11 @@
 # Exposed Optionality — Design
 
-> **Status: design agreed; development started 2026-08-08.** `harmonica-exposed`
-> does not exist yet and `exposedTransaction` is a proposed **future** API. Nothing in
-> this document is shipped or supported until the artifact, the script-classpath
-> handling, transaction tests, and real-DB verification land in Phase 3. Issue
-> #91 stays open until then.
+> **Status: shipped in part (2026-08-09, PR B).** The `exposed/` module
+> (artifact `harmonica-exposed`), the `exposedTransaction` bridge, and embedded
+> SQLite transaction tests (commit + rollback paths) exist and pass
+> (`./gradlew :exposed:test`, 2 tests). Still open in Phase 3: script-classpath
+> wiring for `.kts` migrations (Pitfall F) and a demo project. Issue #91 stays
+> open until the whole flow ships.
 
 ## Problem
 
@@ -29,6 +30,10 @@ migrations. Consequences:
 - `gradle-plugin` no longer special-cases Exposed: `PluginConfig.hasExposed()`
   (the `Class.forName` runtime detection) was **deleted** in PR A. Plugin
   behavior is identical with or without Exposed on the classpath.
+- `harmonica-exposed` exists as module `exposed/` (PR B): `api`-depends on
+  `:core` and `exposed-jdbc:0.61.0` (per spec/tech-notes.md), provides
+  `AbstractMigration.exposedTransaction { }`, and is covered by SQLite
+  transaction tests. `core` and `gradle-plugin` are unchanged by it.
 - **Bridge contract**: the bridge targets a **single supported Exposed major**:
   **Exposed 0.x — pinned 0.61.0** — the major whose JDBC API lives in package
   `org.jetbrains.exposed.sql` (`Database.connect(DataSource)` +
@@ -55,36 +60,51 @@ migrations. Consequences:
 
 ### 2. Optional integration module `harmonica-exposed`
 
-A tiny **separate artifact** (Gradle submodule, e.g. `exposed/`) that:
+A tiny **separate artifact** (Gradle submodule `exposed/`) that:
 
 - `api`-depends on `:core` and on `org.jetbrains.exposed:exposed-jdbc` (plus
-  `exposed-core`) at a pinned current version. `Database.connect(DataSource)`
-  and `transaction()` live in `exposed-jdbc`, so it must be the JDBC module,
-  not just `exposed-core`.
-- Provides a bridge, e.g.:
+  `exposed-core` transitively) at a pinned current version.
+  `Database.connect(...)` and `transaction()` live in `exposed-jdbc`, so it
+  must be the JDBC module, not just `exposed-core`.
+- Provides the bridge (as shipped in PR B):
 
 ```kotlin
-fun AbstractMigration.exposedTransaction(block: () -> Unit) {
-    // Register Exposed ONCE per connection lifecycle, then reuse.
-    // Do NOT call Database.connect() on every invocation (that accumulates
-    // global registrations in TransactionManager and breaks on reconnect).
-    val db = (connection as? Connection)?.exposedDatabase()
-        ?: error("requires a com.improve_future.harmonica.core.Connection")
-    transaction(db) { block() }
+fun AbstractMigration.exposedTransaction(block: Transaction.() -> Unit) {
+    val connection = connection as? Connection
+        ?: error("exposedTransaction requires a com.improve_future.harmonica.core.Connection")
+    transaction(connection.exposedDatabase()) { block() }
 }
 ```
 
-  `exposedDatabase()` adapts the underlying `jdbcConnection` (exposed on
-  `ConnectionInterface`, §1) into a **single-connection `DataSource`** and calls
-  `Database.connect(dataSource)` **once** per connection lifecycle. The
-  `DataSource` overload is used because it is the supported connect form across
-  the pinned Exposed major; the same DataSource is reused for the whole
-  migration so the transaction owner is stable.
+  `exposedDatabase()` (private, in `ExposedMigration.kt`) registers Exposed
+  **once per `Connection` lifecycle** and reuses it:
+
+  - Cache: `WeakHashMap<Connection, Database>` keyed by the `Connection`
+    instance. `Database.connect` is called only when a new key appears, so
+    repeated `exposedTransaction` calls inside one migration reuse the same
+    `Database` instead of accumulating global registrations in
+    `TransactionManager`.
+  - Connect form: `Database.connect(getNewConnection = { proxy }, databaseConfig =
+    DatabaseConfig { defaultMaxAttempts = 1 })`. `defaultMaxAttempts = 1`
+    disables Exposed's SQLException retry loop so DDL is never re-executed.
+  - The connector returns a **`java.lang.reflect.Proxy`** implementing
+    `java.sql.Connection` that delegates **every method to the connection's
+    current `jdbcConnection`** except `commit`, `rollback`, and `close`, which
+    are **no-ops** — harmonica's outer `Connection.transaction` owns the real
+    commit/rollback/close (Option A, §2.1). `JdbcConnectionImpl` (exposed-jdbc)
+    delegates through the proxy, so no Exposed path reaches the physical
+    connection's commit/rollback/close.
+  - The `Database` holds only a `WeakReference` to the `Connection` (the proxy
+    resolves `jdbcConnection` on every call), avoiding the classic
+    weak-key/strong-value leak.
 
 - The bridge is an extension on **`AbstractMigration`** (or the receiver is the
   migration itself), because inside `up()` the receiver is `AbstractMigration`
   and its `connection` field is typed `ConnectionInterface` — an extension on
   the concrete `Connection` would not resolve. See Pitfall E below.
+- The block receiver is Exposed's `Transaction` (`block: Transaction.() -> Unit`),
+  so DSL calls that need the transaction receiver (e.g. `exec`) work inside
+  `exposedTransaction {}`.
 
 ### 2.1 Transaction ownership (the critical design point)
 
@@ -99,39 +119,50 @@ pointing at the closed connection).
 Decide **one owner** — **resolved (2026-08-08): Option A, harmonica owns the
 transaction.**
 
-- **Option A (chosen): harmonica owns the transaction.** The bridge binds
-  harmonica's connection into Exposed's manager and runs the Exposed DSL
-  *without* an Exposed-managed commit (i.e. `TransactionManager`/stack-based
-  registration, or `transaction(db){}` where the commit is a no-op because the
-  outer `Connection.transaction` commits). Users write the Exposed DSL; harmonica
-  does commit/rollback/close.
+- **Option A (chosen, implemented in PR B): harmonica owns the transaction.** The
+  bridge binds harmonica's connection into Exposed's manager and runs the
+  Exposed DSL *without* an Exposed-managed commit: `transaction(db){}` runs
+  against the no-op proxy (§2), so Exposed's commit/rollback/close are inert and
+  the outer `Connection.transaction` commits. Users write the Exposed DSL;
+  harmonica does commit/rollback/close. Verified by the SQLite tests: the commit
+  path persists the Exposed DDL+insert; the failure path (`error("boom")` inside
+  `exposedTransaction`) rolls back the CREATE TABLE and reconnects the closed
+  connection.
 - **Option B (rejected): Exposed owns the transaction.** Then the harmonica runner must
   NOT wrap migrations in `Connection.transaction` when the bridge is used
   (require an explicit opt-in), and harmonica's `Connection.transaction` is
   bypassed.
 
-Until this is decided, the snippet is illustrative only and must not be shipped
-as written.
-
 ### 2.2 Other pitfalls to design around
 
 - **`setTransactionIsolation` no-op proxy**: `Connection.connect()` wraps every
   non-SQLite JDBC connection in a proxy that overrides `setTransactionIsolation`
-  to a no-op (`Connection.kt:18`). Exposed may derive isolation from its own
-  config and try to apply it — it will be silently ignored. Acceptable for now;
-  document it, or decide whether the proxy override is still needed at all.
-- **Reconnect invalidation**: the proxy is recreated on every reconnect
-  (`Connection.kt:29-38`). A cached Exposed `Database` bound to an old connection
-  is stale. The bridge must re-register after reconnect (key the cache by
-  connection instance) or, per Option A, register fresh within each migration.
-- **Single-threaded assumption**: `Database.connect(DataSource)` wrapping one
-  connection reuses that connection for every transaction and is not
-  thread-safe. The migration runner is single-threaded, so this holds —
-  document it.
+  to a no-op (`Connection.kt:18`). The bridge proxy delegates isolation through
+  to that proxy, so Exposed's isolation setting is silently ignored for
+  non-SQLite. For SQLite, core exposes the raw connection and Exposed's default
+  (SERIALIZABLE) applies. Acceptable for now; revisit whether core's proxy
+  override is still needed at all.
+- **Reconnect invalidation (resolved in PR B)**: harmonica reconnects a closed
+  connection lazily (`Connection.kt:29-38`). The bridge proxy resolves
+  `jdbcConnection` **on every method call**, so after a reconnect it
+  automatically targets the fresh connection. The cache is keyed by the
+  `Connection` instance, so a *new* `Connection` (e.g. a new migration run)
+  gets its own `Database`. The rollback test exercises this: after the failed
+  transaction closes the connection, `doesTableExist` reconnects and the Exposed
+  registration still resolves.
+- **Single-threaded assumption**: the cached `Database` wraps one connection and
+  is reused for every Exposed transaction; it is not thread-safe. The migration
+  runner is single-threaded, so this holds. The `WeakHashMap` cache is likewise
+  not thread-safe — document the single-threaded assumption.
 - **`autoCommit`**: harmonica forces `autoCommit = false` (connect + at the top
-  of `transaction`). Exposed transactions assume `autoCommit = false` too;
-  verify the pinned Exposed version doesn't restore `autoCommit = true` after a
-  transaction (harmonica's next `transaction` self-heals via `Connection.kt:108`).
+  of `transaction`). Exposed 0.61's `ThreadLocalTransaction` init also sets
+  `autoCommit = false` on the wrapped connection; it does not restore
+  `autoCommit = true` after a transaction, so the two agree. Verified by the
+  transaction tests.
+- **Retry re-execution (guarded)**: Exposed retries failed transactions up to
+  `defaultMaxAttempts` times, which would re-execute DDL. The bridge sets
+  `defaultMaxAttempts = 1` (attempts counter starts at 0, so exactly one
+  execution).
 - **Name collision**: `core` has an (empty) `com.improve_future.harmonica.core.Database`
   class (`Database.kt`). Avoid wildcard imports in the bridge so it doesn't
   collide with `org.jetbrains.exposed.sql.Database`.
@@ -185,6 +216,16 @@ class M20260801_Migrate : AbstractMigration() {
   Exposed (or uses it only for diagnostics).
 - Documented in README + wiki with the two usage paths above.
 
+**Shipped in PR B (2026-08-09):** the `exposed/` module builds with
+`exposed-jdbc:0.61.0`; `exposedTransaction` runs the Exposed DSL inside
+harmonica's `Connection.transaction` (Option A) with commit + rollback proven by
+SQLite tests (`:exposed:test`); full `./gradlew build` is green with and without
+Exposed on the classpath; `:core` still has zero Exposed references.
+
+**Remaining for Phase 3:** script-classpath wiring for `.kts` migrations
+(Pitfall F) and the demo project against a real DB (SQLite here; PostgreSQL/MySQL
+deferred to Phase 4 integration tests).
+
 ## Open questions
 
 Resolved (2026-08-08):
@@ -194,9 +235,16 @@ Resolved (2026-08-08):
 - **Exposed 0.61.0** — latest 0.x, JDBC API in `org.jetbrains.exposed.sql`.
 - **Option A** — harmonica owns the transaction (no Exposed-managed commit).
 
+Resolved (2026-08-09, PR B):
+
+- **No-op-commit wrapper needed? Yes** — verified empirically. Plain
+  `transaction(db){}` on harmonica's raw connection would commit/rollback/close
+  the shared physical connection (a double commit on success, double rollback +
+  stale Database on failure). The bridge therefore wraps the connection in a
+  `java.lang.reflect.Proxy` that no-ops `commit`/`rollback`/`close` and
+  delegates everything else (see §2). Both the commit path and the rollback
+  path are covered by the SQLite tests.
+
 Remaining:
 
-- `exposedTransaction` commit/rollback detail under Option A: whether it needs
-  a no-op-commit wrapper or plain `transaction(db){}` is safe because the outer
-  `Connection.transaction` commits (verify empirically in Phase 3).
 - Script classpath wiring for `.kts` migrations (Pitfall F).

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -2,10 +2,10 @@
 
 > **Status: shipped in part (2026-08-09, PR B).** The `exposed/` module
 > (artifact `harmonica-exposed`), the `exposedTransaction` bridge, and embedded
-> SQLite transaction tests (commit + rollback paths) exist and pass
-> (`./gradlew :exposed:test`, 3 tests). Still open in Phase 3: script-classpath
-> wiring for `.kts` migrations (Pitfall F) and a demo project. Issue #91 stays
-> open until the whole flow ships.
+> SQLite transaction tests (commit + rollback + reconnect + SQLException
+> propagation) exist and pass (`./gradlew :exposed:test`, 4 tests). Still open
+> in Phase 3: script-classpath wiring for `.kts` migrations (Pitfall F) and a
+> demo project. Issue #91 stays open until the whole flow ships.
 
 ## Problem
 
@@ -76,9 +76,8 @@ fun AbstractMigration.exposedTransaction(block: Transaction.() -> Unit) {
 }
 ```
 
-  `exposedDatabase()` (private, in `ExposedMigration.kt`) registers Exposed
+- `exposedDatabase()` (private, in `ExposedMigration.kt`) registers Exposed
   **once per `Connection` lifecycle** and reuses it:
-
   - Cache: `WeakHashMap<Connection, Database>` keyed by the `Connection`
     instance. `Database.connect` is called only when a new key appears, so
     repeated `exposedTransaction` calls inside one migration reuse the same
@@ -93,7 +92,11 @@ fun AbstractMigration.exposedTransaction(block: Transaction.() -> Unit) {
     are **no-ops** — harmonica's outer `Connection.transaction` owns the real
     commit/rollback/close (Option A, §2.1). `JdbcConnectionImpl` (exposed-jdbc)
     delegates through the proxy, so no Exposed path reaches the physical
-    connection's commit/rollback/close.
+    connection's commit/rollback/close. Exceptions the driver throws while a
+    delegated method runs are unwrapped from the reflection
+    `InvocationTargetException` and rethrown unchanged, so `SQLException`s keep
+    their type instead of surfacing as `UndeclaredThrowableException` (see
+    §2.2).
   - The `Database` holds only a `WeakReference` to the `Connection` (the proxy
     resolves `jdbcConnection` on every call), avoiding the classic
     weak-key/strong-value leak.
@@ -173,6 +176,13 @@ transaction.**
   **and** `setReadOnly(false)` on the wrapped connection. `setReadOnly` is *not*
   overridden anywhere, so for PostgreSQL/MySQL it executes driver-side state
   changes on the open transaction. Deferred to the Phase 4 real-DB work.
+- **Exception typing preserved**: `method.invoke` wraps any exception the driver
+  throws in `InvocationTargetException`, which the JDK proxy would otherwise
+  surface as `UndeclaredThrowableException` (a `RuntimeException`, not a
+  `SQLException`), breaking Exposed's `SQLException` handling. The proxy's
+  invocation handler unwraps `InvocationTargetException` and rethrows the
+  original `targetException`, so `SQLException`s propagate unchanged and the
+  retry/rollback behavior described above still applies.
 - **Exposed's global registry grows in long-lived JVMs (known limitation)**: 
   `Database.connect` registers every `Database` in Exposed's global
   `TransactionManager` (`ConcurrentHashMap` + `ConcurrentLinkedDeque`) for the
@@ -182,10 +192,18 @@ transaction.**
   daemon) leaves one permanently-registered `Database` whose connector holds a
   dead `WeakReference`. Bounded per run, unbounded over a long-lived JVM.
   Acceptable for a migration tool (short-lived task JVMs); revisit if harmonica
-  gains a long-lived server mode. Note also that a new `Database.connect`
-  overwrites Exposed's *global default* manager, so a bare `transaction {}` in
-  user code afterwards routes to the bridge's proxy-backed `Database` —
-  harmless for harmonica's flow.
+  gains a long-lived server mode.
+- **Global default manager side effect (restriction, not harmless)**: a new
+  `Database.connect` overwrites Exposed's *global default* manager, so afterward
+  a bare `transaction {}` in user code routes to the bridge's proxy-backed
+  `Database` instead of the caller's. That is **not** harmless: the proxy is
+  bound to one specific `Connection` under the single-threaded assumption
+  (§2.2), so concurrent or subsequent bare `transaction {}` calls in a shared
+  JVM would target the wrong connection. Consequently `harmonica-exposed` is
+  supported only for short-lived, single-run JVMs (the migration task): do not
+  use it alongside other Exposed code (bare `transaction {}`, a second
+  `Database.connect`) in the same JVM. The previous manager is not restored and
+  `closeAndUnregister` is not called (core purity, above).
 - **Script classpath (Pitfall F)**: migration `.kts` files are evaluated by the
   Gradle plugin's JSR-223 engine on the **plugin's classpath**
   (`AbstractMigrationTask.kt:33-37`). Adding `harmonica-exposed` via the user's
@@ -238,13 +256,15 @@ class M20260801_Migrate : AbstractMigration() {
 
 **Shipped in PR B (2026-08-09):** the `exposed/` module builds with
 `exposed-jdbc:0.61.0`; `exposedTransaction` runs the Exposed DSL inside
-harmonica's `Connection.transaction` (Option A) proven by three SQLite tests
+harmonica's `Connection.transaction` (Option A) proven by four SQLite tests
 (`:exposed:test`): commit (DDL+insert persist; Exposed did not close the
 connection or restore autoCommit), rollback (harmonica DSL + Exposed DSL in one
-migration both rolled back — one shared transaction), and reconnect (a second
-`exposedTransaction` succeeds through harmonica's reconnected connection). Full
-`./gradlew build` is green with and without Exposed on the classpath; `:core`
-still has zero Exposed references.
+migration both rolled back — one shared transaction), reconnect (a second
+`exposedTransaction` succeeds through harmonica's reconnected connection), and
+SQLException propagation (a driver-level error thrown through the proxy keeps
+its `SQLException` type instead of surfacing as
+`UndeclaredThrowableException`). Full `./gradlew build` is green with and
+without Exposed on the classpath; `:core` still has zero Exposed references.
 
 **Remaining for Phase 3:** script-classpath wiring for `.kts` migrations
 (Pitfall F) and the demo project against a real DB (SQLite here; PostgreSQL/MySQL

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-08 (**28 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-09 (**29 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 
@@ -26,10 +26,11 @@ superseded by Phase 0.
 | # | Title | Plan |
 | --- | --- | --- |
 | 189 | `isSubtypeOf` in scanner swallows all `Throwable` | Narrow to recoverable exceptions to match `loadClass` (PR #188); small fix in `JarmonicaTaskMain`. |
+| 196 | Real-DB tests must cover both configs: with and without Exposed | Phase 3/4 verification: run the migration flow against a real DB with and without `harmonica-exposed` on the classpath (SQLite embedded now, PostgreSQL/MySQL in Phase 4). |
 | 182 | README JitPack badge shows nothing | Fix JitPack badge so it renders (README badge URLs fixed in PR #181, but this badge still broken). |
 | 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
 | 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |
-| 91 | Exposed Library must be loaded by Class.forName | Resolved by [exposed-integration.md](exposed-integration.md): core has no Exposed reference. |
+| 91 | Exposed Library must be loaded by Class.forName | Core has no Exposed reference (PR A); `harmonica-exposed` bridge shipped (Phase 3, PR B). Issue stays open until the whole flow ships (script classpath + demo project) — see [exposed-integration.md](exposed-integration.md). |
 | 138 | Is there a need to make AbstractColumn internal? | Open up custom-column extension points (make `AbstractColumn`/`ColumnBuilder` public, document custom column pattern). |
 | 141 | Add support to more column types | Long is done; add Enumeration and other missing types (see Exposed type list). |
 | 145 | Add alter column function | Add `alterColumn` to change type/options. |

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -204,20 +204,20 @@ gradle-plugin; Phase 0 baseline was 66).
 Outcome: `core` has zero Exposed references; users decide whether to use
 Exposed, and integration is documented. Full design: [exposed-integration.md].
 
-Status: **in progress (decisions resolved 2026-08-08).** Plan: ship
-`harmonica-exposed` as a separate module pinned to Exposed 0.61.0; Option A
-transaction ownership (harmonica owns).
+Status: **in progress.** PR A (2026-08-08) removed the dead `hasExposed` flag,
+exposed `jdbcConnection` on `ConnectionInterface`, and deleted
+`PluginConfig.hasExposed()`. **PR B (2026-08-09)** adds the `exposed/` module
+(`harmonica-exposed`, pinned to Exposed 0.61.0), the `exposedTransaction` bridge
+(Option A transaction ownership via a no-op commit/rollback/close proxy), and
+SQLite commit+rollback transaction tests. Remaining in Phase 3: script-classpath
+wiring for `.kts` migrations (Pitfall F) and a demo project. Plan:
 
-- Remove dead `hasExposed` flag plumbing from `Connection.kt` (currently a
-  no-op ternary).
-- Expose the underlying `java.sql.Connection` from `Connection`.
-- Provide an **optional** artifact/module `harmonica-exposed` that bridges
-  Exposed transactions onto harmonica's connection lifecycle (users who add it
-  get Exposed; everyone else is unaffected — compilation cannot fail).
-- Keep runtime detection (`Class.forName`) only where it adds value; otherwise
-  delete `PluginConfig.hasExposed()`.
-- Resolve issues #91, #80 and the concern behind #160 (document, upgrade,
-  reflect).
+- Wire the script classpath so `.kts` migrations can reach `harmonica-exposed`
+  and Exposed (Pitfall F: the JSR-223 engine runs on the plugin's classpath).
+- Demo project compiling a migration using the Exposed DSL and running it
+  against a real DB (SQLite here; PostgreSQL/MySQL deferred to Phase 4).
+- Close issues #91, #80, and the concern behind #160 once the flow ships
+  (document, upgrade, reflect).
 
 ### Phase 4 — Tests & DB environment
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -75,9 +75,10 @@ Consequences for the restart:
 - These unverified changes are the reason `master` was left behind — do not
   fast-forward `master` until Phase 0 is green and DB tests (Phase 4) pass.
 - **Status (post-Phase 0/2):** the split build is verified — `core` and
-  `gradle-plugin` build, test (72 tests green), and package correctly on Java 25
-  and in CI; `document/` is excluded from the build. Phase 0 also proved the
-  POM/publication config (PR #183) and the Groovy→Kotlin DSL migration. The
+  `gradle-plugin` build, test (72 tests green; snapshot before the Phase 3
+  `exposed` module — see README for the current 76), and package correctly on
+  Java 25 and in CI; `document/` is excluded from the build. Phase 0 also proved
+  the POM/publication config (PR #183) and the Groovy→Kotlin DSL migration. The
   remaining unverified risk is real-DB behavior, which Phase 4 covers.
 
 ## 4. Phases
@@ -165,7 +166,8 @@ Outcome: no dead repositories or unmaintained libraries in the build.
 
 Status: **merged 2026-08-01 (PRs #184-#188).** All build files now use only
 Maven Central (`document/` excluded from build). 72 tests green (68 core + 4
-gradle-plugin; Phase 0 baseline was 66).
+gradle-plugin; Phase 0 baseline was 66; snapshot before the Phase 3 `exposed`
+module — see README for the current 76).
 
 - `gradle.properties`: `kotlin_version` → 2.3.x. — **done in Phase 0** (2.3.20).
 - Dead repositories: **gone** — jcenter/bintray/space removed; jitpack removed
@@ -209,8 +211,9 @@ exposed `jdbcConnection` on `ConnectionInterface`, and deleted
 `PluginConfig.hasExposed()`. **PR B (2026-08-09)** adds the `exposed/` module
 (`harmonica-exposed`, pinned to Exposed 0.61.0), the `exposedTransaction` bridge
 (Option A transaction ownership via a no-op commit/rollback/close proxy), and
-SQLite commit+rollback transaction tests. Remaining in Phase 3: script-classpath
-wiring for `.kts` migrations (Pitfall F) and a demo project. Plan:
+SQLite transaction tests covering commit, rollback, reconnect, and SQLException
+propagation through the proxy. Remaining in Phase 3: script-classpath wiring
+for `.kts` migrations (Pitfall F) and a demo project. Plan:
 
 - Wire the script classpath so `.kts` migrations can reach `harmonica-exposed`
   and Exposed (Pitfall F: the JSR-223 engine runs on the plugin's classpath).
@@ -326,3 +329,9 @@ Resolved for Phase 3 (2026-08-08):
 - Transaction ownership: **Option A — harmonica owns the transaction** (bridge
   binds harmonica's connection into Exposed's manager; no Exposed-managed
   commit).
+- Usage restriction (resolved during PR #198): `harmonica-exposed` is supported
+  only in **short-lived, single-run JVMs** — its `Database.connect` overwrites
+  Exposed's global default manager and is never unregistered (core purity
+  forbids a close hook), so it must not be combined with other Exposed code
+  (bare `transaction {}`, another `Database.connect`) in a shared JVM. See
+  exposed-integration.md §2.2.

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -5,14 +5,16 @@ Facts gathered on 2026-08-01. Update this file as versions change.
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **72 unit tests pass (68 core,
-  4 gradle-plugin), 0 failures/errors** (Phase 0 baseline was 66; Phase 2 added
-  6 InflectionsTest cases).
+  `./gradlew clean build` is green on Java 25; **74 unit tests pass (68 core,
+  4 gradle-plugin, 2 exposed), 0 failures/errors** (Phase 0 baseline was 66;
+  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 2 ExposedMigrationTest
+  cases).
 - `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
-  + `java.sourceCompatibility/targetCompatibility = 1.8` in both modules.
-  Verified by `javap`: all main classes are class-file major **52** (JVM 8).
+  + `java.sourceCompatibility/targetCompatibility = 1.8` in all three modules
+  (`core`, `exposed`, `gradle-plugin`). Verified by `javap`: all main classes are
+  class-file major **52** (JVM 8).
 - `document/` is **dropped from the root build** (`settings.gradle.kts` includes
-  only `core`, `gradle-plugin`). The nested Gradle 4.9 build is untouched.
+  only `core`, `exposed`, `gradle-plugin`). The nested Gradle 4.9 build is untouched.
 - CI replaced: `gradle.yml` + `.circleci/config.yml` → `ci.yml` +
   `jvm8-bytecode.yml` (see [ci.md](ci.md)).
 
@@ -44,6 +46,13 @@ Key references:
 | `commons-codec` | **DONE** | 1.15 dropped — unused (PR #184). |
 | `com.github.cesarferreira:kotlin-pluralizer` | **DONE** | removed (PR #187); internal `singularize()` port, see the note below (issue #140 resolved). |
 
+### exposed
+
+| Dependency | Status | Notes |
+| --- | --- | --- |
+| `org.jetbrains.exposed:exposed-jdbc` | **DONE** | 0.61.0 pinned (api; Phase 3, PR B). `exposed-core` arrives transitively; never declare it directly. |
+| `org.xerial:sqlite-jdbc` | **DONE** | testImplementation-only (Phase 3, PR B) for embedded-DB bridge tests; see the gradle-plugin row note on driver placement. |
+
 ### gradle-plugin
 
 | Dependency | Status | Notes |
@@ -54,7 +63,7 @@ Key references:
 | `org.reflections:reflections` | **DONE** | replaced with a classpath scanner in `JarmonicaTaskMain` (Phase 2, PRs #185/#188). |
 | `kotlinx-html-jvm` | **DONE** | dropped here (PR #184); real consumer is `document` (Phase 7). |
 | `kotlin-test` / `kotlin-test-junit5` | **DONE** | pinned to 2.3.20 (were unversioned). |
-| JDBC test drivers (mysql, postgresql, sqlite, mssql) | **DONE** | removed (PR #184); DB drivers move to the Phase 4 integration module. |
+| JDBC test drivers (mysql, postgresql, mssql) | **DONE** | removed (PR #184); server DB drivers move to the Phase 4 integration module. Exception: `org.xerial:sqlite-jdbc` is re-added as `testImplementation`-only in the `exposed` module (Phase 3, PR B) for embedded-DB Option-A transaction tests — nothing leaks into published artifacts. |
 | `com.gradle.plugin-publish` | **DONE** | 0.9.10 → **2.1.1**; legacy `pluginBundle` block removed (2.x moved config into `gradlePlugin`). |
 | `org.jetbrains.dokka` | **DONE** | 0.9.17 → **2.2.0**; removed the removed `outputFormat` DSL. Docs refresh is Phase 7. |
 
@@ -73,7 +82,7 @@ Key references:
 - Gradle 9 task validation: `JavaExec` is abstract in Gradle 9, so the
   Jarmonica task subclasses are `abstract`; every task class carries
   `@DisableCachingByDefault` (validatePlugins requirement).
-- `Connection.kt:153` — `toUpperCase()` → `uppercase()` (deprecation was an
+- `Connection.kt:152` — `toUpperCase()` → `uppercase()` (deprecation was an
   error under Kotlin 2.3).
 
 Still open (not Phase 0):

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -5,9 +5,9 @@ Facts gathered on 2026-08-01. Update this file as versions change.
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **74 unit tests pass (68 core,
-  4 gradle-plugin, 2 exposed), 0 failures/errors** (Phase 0 baseline was 66;
-  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 2 ExposedMigrationTest
+  `./gradlew clean build` is green on Java 25; **75 unit tests pass (68 core,
+  4 gradle-plugin, 3 exposed), 0 failures/errors** (Phase 0 baseline was 66;
+  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 3 ExposedMigrationTest
   cases).
 - `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
   + `java.sourceCompatibility/targetCompatibility = 1.8` in all three modules

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,13 +1,14 @@
 # Toolchain & Dependency Research
 
-Facts gathered on 2026-08-01. Update this file as versions change.
+Facts gathered on 2026-08-01 (test counts updated 2026-08-09). Update this
+file as versions change.
 
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **75 unit tests pass (68 core,
-  4 gradle-plugin, 3 exposed), 0 failures/errors** (Phase 0 baseline was 66;
-  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 3 ExposedMigrationTest
+  `./gradlew clean build` is green on Java 25; **76 unit tests pass (68 core,
+  4 gradle-plugin, 4 exposed), 0 failures/errors** (Phase 0 baseline was 66;
+  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 4 ExposedMigrationTest
   cases).
 - `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
   + `java.sourceCompatibility/targetCompatibility = 1.8` in all three modules

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -9,16 +9,23 @@
 
 ## Current state
 
-- Unit tests exist in `core` and `gradle-plugin` (JUnit 6.1.2, `useJUnitPlatform`).
-  They use **stubs, not real JDBC drivers**: core's DB tests go through
+- Unit tests exist in `core`, `exposed`, and `gradle-plugin` (JUnit 6.1.2,
+  `useJUnitPlatform`). `core`/`gradle-plugin` use **stubs, not real JDBC
+  drivers**: core's DB tests go through
   `StubConnection`/`StubDbAdapter`/`StubMigration` (package-private), adapter
   tests inspect `buildColumnDeclarationForCreateTableSql` by reflection, and
-  `ConnectionTest` only asserts the connection-URI string — **no DBMS is
-  actually exercised by unit tests**.
+  `ConnectionTest` only asserts the connection-URI string — no server DBMS is
+  exercised there.
+- The `exposed` module runs **real embedded-SQLite transaction tests** (Phase 3,
+  PR B): `ExposedMigrationTest` drives the Exposed DSL inside harmonica's
+  `Connection.transaction` against a temp-file SQLite DB, covering both the
+  commit path (DDL + insert persist) and the rollback path (exception inside
+  `exposedTransaction` rolls back and reconnects). This is the first real-DB
+  test in the repo, and it is green without Docker.
 - Real-DB tests (`harmonica_test`) require a live PostgreSQL/MySQL with a
   `developer/developer` user and a `harmonica_test` database; they are a
   separate Gradle project and only run manually.
-- This machine: no Docker, no local DBMS yet.
+- This machine: no Docker, no local DBMS yet (SQLite embedded tests run fine).
 
 ## Plan
 
@@ -53,11 +60,11 @@ services:
     ports: ["3306:3306"]
 ```
 
-- SQLite needs no server. It is **not** covered by unit tests today (only a URI
-  string is asserted); add a **Docker-free SQLite integration path** that runs
-  in plain CI: `org.xerial:sqlite-jdbc` + a temp-file/`:memory:` DB, gated by
-  the same env-var helper. This gives an always-green real-DB smoke test
-  without Docker.
+- SQLite needs no server. It **is** covered by the embedded tests in the
+  `exposed` module today (Phase 3, PR B); keep an always-green SQLite path in
+  CI (`org.xerial:sqlite-jdbc` + a temp-file/`:memory:` DB) and extend the
+  pattern to a **Docker-free SQLite integration path** for `core` gated by the
+  same env-var helper.
 - **H2 as the Docker-free alternative**: `Connection.buildConnectionUriFromDbConfig`
   returns `""` for `Dbms.H2` and `SqlServerAdapter` is 100% TODO. Add H2
   support as an embedded (no-server) DBMS alongside SQLite; defer SQL Server /


### PR DESCRIPTION
Part of Phase 3 (Exposed optionality), stacked on PR #197 — per spec/plan.md Phase 3 and spec/exposed-integration.md §2.

## What is this pull request for? Why do you create this pull request?

Ship the optional `harmonica-exposed` artifact and the `exposedTransaction` bridge (Option A: harmonica owns the transaction), plus embedded-SQLite transaction tests. Core and gradle-plugin are untouched; users who don't add the module are unaffected.

## What is changed?

- New `exposed/` Gradle module: `api`-depends on `:core` and `org.jetbrains.exposed:exposed-jdbc:0.61.0` (`exposed-core` transitive); `org.xerial:sqlite-jdbc` is `testImplementation`-only. JVM 8 target preserved (verified via javap).
- `AbstractMigration.exposedTransaction(block: Transaction.() -> Unit)` runs the Exposed DSL inside harmonica's `Connection.transaction`:
  - `Database.connect(getNewConnection = { proxy })` registered once per `Connection` lifecycle via a `WeakHashMap` cache (no global-registration accumulation, no stale Database on reconnect).
  - A `java.lang.reflect.Proxy` over `java.sql.Connection` no-ops `commit`/`rollback`/`close` and delegates everything else to `jdbcConnection` (resolved per call, so reconnect-safe).
  - `defaultMaxAttempts = 1` disables Exposed's SQLException retry loop (no DDL re-execution).
- Tests (`ExposedMigrationTest`): commit path (Exposed DDL+insert persist through harmonica's commit) and rollback path (`error()` inside `exposedTransaction` → CREATE TABLE rolled back, closed connection reconnects). 2 tests, green.
- `settings.gradle.kts` includes `exposed`; `jvm8-bytecode.yml` now asserts major-52 on `exposed/.../kotlin/main`.
- Specs updated (plan, exposed-integration, tech-notes, ci, testing, issues-triage, README): shipped state, bridge design, sqlite test-driver exception, three-module lists, test counts, open-issue snapshot + #196.

## Other comment

Verified against Exposed 0.61.0 sources: `JdbcConnectionImpl` (exposed-jdbc) delegates commit/rollback/close through the proxy, so no Exposed path reaches the physical connection's transaction controls; `ThreadLocalTransaction` init sets `autoCommit = false` and never restores it; dialect resolution (`databaseDialectName`) works through the proxy.

Full `./gradlew build` green locally (74 tests). Remaining in Phase 3: script-classpath wiring for .kts migrations (Pitfall F) and a demo project — tracked in spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Exposed integration for running Exposed database operations within Harmonica-managed migrations.
  - Added transaction support that preserves commit and rollback behavior across JDBC and Exposed operations.
  - Added SQLite coverage for successful migrations, rollback scenarios, and reconnects.

- **Bug Fixes**
  - Improved the deprecated connection API message to provide clearer guidance.

- **Documentation**
  - Updated module, integration, testing, CI, and project planning documentation to reflect Exposed support and current test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->