### PR TITLE
Reconcile spec docs with Phase 3 reality (plan-review)

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -16,8 +16,8 @@ plan to restart and modernize the project.
 
 ## Current state (baseline, branch `develop`)
 
-> Snapshot taken 2026-08-08, after Phase 0 (toolchain) and Phase 2 (dead-dep
-> removal). Update this list when the baseline advances.
+> Snapshot taken 2026-08-09, after Phase 3 (Exposed bridge, PRs #197-#199).
+> Update this list when the baseline advances.
 
 - Kotlin **2.3.20**, Gradle wrapper **9.6.1**, `jvmTarget = 1.8` (class-file
   major 52 asserted in CI)
@@ -26,7 +26,7 @@ plan to restart and modernize the project.
 - Publish target: plugin-publish + OSSRH staging (jcenter/bintray removed)
 - CI: GitHub Actions only — `ci.yml` (PR/push, Temurin JDK 25,
   `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
-  `actions/setup-java@5.6.0`), `jvm8-bytecode.yml` (major-52 assertion),
+  `actions/setup-java@5.7.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (Dependabot). CircleCI removed.
 - Three active modules: `core`, `exposed`, `gradle-plugin` — **76 tests green**
   (68 core + 4 plugin + 4 exposed); `document` (nested standalone build) is
@@ -40,7 +40,7 @@ plan to restart and modernize the project.
   [`exposed-integration.md`](exposed-integration.md)
 - Tests for real DBMS still live in the separate `harmonica_test` repository —
   to be merged in Phase 4
-- **`develop` is 56 commits ahead of `master`** — Phase 4 (real-DB tests) must
+- **`develop` is 75 commits ahead of `master`** — Phase 4 (real-DB tests) must
   pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 
 ## Machine environment (current)

--- a/spec/ci.md
+++ b/spec/ci.md
@@ -54,7 +54,7 @@ As landed:
 - **Steps**:
   - `actions/checkout@v7` with `persist-credentials: false` (no step needs Git
     authentication after checkout; Gradle doesn't use the persisted credential).
-  - `actions/setup-java@v5.6.0` with Temurin **JDK 25** — `setup-gradle` does
+  - `actions/setup-java@v5.7.0` with Temurin **JDK 25** — `setup-gradle` does
     **not** install a JDK and ignores `distribution`/`java-version` inputs
     (only `actions/setup-java` selects the JDK).
   - `gradle/actions/setup-gradle@v6` with wrapper validation, build cache, and
@@ -131,18 +131,18 @@ updates:
   opens PRs against them. Dependabot PRs **#171** (dokka 2.2.0), **#172**
   (plugin-publish 2.1.1), and **#178** (wrapper 9.6.1) were superseded by the
   Phase 0 toolchain PR and are closed. Later CI-action bumps merged: #170
-  (checkout v7), #191 (setup-gradle v6), #192 (setup-java v5.6.0). A Kotlin
-  `jvm` plugin bump (PR #193) is open with a **decline recommendation** — see
-  `spec/plan.md` §6.
+  (checkout v7), #191 (setup-gradle v6), #192 (setup-java v5.6.0), #195
+  (setup-java v5.7.0). A Kotlin `jvm` plugin bump (PR #193) is open with a
+  **decline recommendation** — see `spec/plan.md` §6.
 
 ## 4. Action version policy
 
 - Pin by **major tag** (e.g. `@v7`) and let Dependabot keep them current;
-  Dependabot may propose full-version pins (e.g. `setup-java@v5.6.0`) — accept
+  Dependabot may propose full-version pins (e.g. `setup-java@v5.7.0`) — accept
   those. Full SHA-pinning is optional hardening for stricter projects.
 - Recommended actions: `actions/checkout@v7` (PR #170), `gradle/actions/setup-gradle@v6`
   (PR #191; official Gradle action — replaces manual `setup-java` + cache for
-  Gradle projects), `actions/setup-java@v5.6.0` (PR #192; Temurin JDK 25),
+  Gradle projects), `actions/setup-java@v5.7.0` (PRs #192/#195; Temurin JDK 25),
   `actions/upload-artifact@v4` (if artifacts needed later). Dependabot keeps
   them current.
 

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -5,7 +5,7 @@
 > SQLite transaction tests (commit + rollback + reconnect + SQLException
 > propagation) exist and pass (`./gradlew :exposed:test`, 4 tests). Still open
 > in Phase 3: script-classpath wiring for `.kts` migrations (Pitfall F) and a
-> demo project. Issue #91 stays open until the whole flow ships.
+> demo project. Issue #91 was closed at the Phase 3 merge (2026-08-09).
 
 ## Problem
 

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-09 (**29 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-09 (**28 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 
@@ -30,7 +30,6 @@ superseded by Phase 0.
 | 182 | README JitPack badge shows nothing | Fix JitPack badge so it renders (README badge URLs fixed in PR #181, but this badge still broken). |
 | 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
 | 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |
-| 91 | Exposed Library must be loaded by Class.forName | Core has no Exposed reference (PR A); `harmonica-exposed` bridge shipped (Phase 3, PR B). Issue stays open until the whole flow ships (script classpath + demo project) — see [exposed-integration.md](exposed-integration.md). |
 | 138 | Is there a need to make AbstractColumn internal? | Open up custom-column extension points (make `AbstractColumn`/`ColumnBuilder` public, document custom column pattern). |
 | 141 | Add support to more column types | Long is done; add Enumeration and other missing types (see Exposed type list). |
 | 145 | Add alter column function | Add `alterColumn` to change type/options. |
@@ -66,6 +65,11 @@ superseded by Phase 0.
 
 ## Closed-but-related (context)
 
+- #91 (closed 2026-08-09 at the Phase 3 merge, PRs #197-#199): "Exposed Library
+  must be loaded by Class.forName" — `core` has no Exposed reference and the
+  `harmonica-exposed` bridge shipped. Script-classpath wiring (Pitfall F) and
+  the demo project remain as Phase 3 work, tracked by [plan.md](plan.md), not by
+  this issue.
 - #168 (PR, merged): bug-build-issue — build fixes already on `develop`.
 - #160 (closed): "How it should be used with Exposed" — reopened conceptually in
   exposed-integration.md.

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -34,9 +34,10 @@ State:
 
 - `master` (origin/master @ `3b423c6`) has not been touched in years and is the
   direct ancestor of `develop` (merge-base == master HEAD).
-- `develop` is **56 commits ahead** (module split into `core`/`gradle-plugin`,
-  jcenter removal work, MIT license change, CI-action bumps, etc.) but **never
-  fully tested or released** — this is why master was left behind.
+- `develop` is **75 commits ahead** (module split into `core`/`gradle-plugin`,
+  jcenter removal work, MIT license change, CI-action bumps, Phase 3 Exposed
+  bridge, etc.) but **never fully tested or released** — this is why master was
+  left behind.
 
 Policy going forward (Git Flow, simplified):
 
@@ -49,8 +50,9 @@ Policy going forward (Git Flow, simplified):
    clean fast-forward, no merge conflict risk.)
 4. `master` becomes the source of released tags (JitPack builds from tags).
 5. Old branches on the remote (`feature/core_split`, `feature/maven-plugin`,
-   `feature/version_up`, `feature/exposed`, `feature/show_sql`, `feature/mit-license`,
+   `feature/version_up`, `feature/exposed`, `feature/show_sql`,
    `feature/split`) are either resurrected as issues or deleted after review.
+   (`feature/mit-license` was merged via PR #166 and is gone.)
 
 ## 3.5. Risk register — unverified changes already on `develop`
 
@@ -76,7 +78,7 @@ Consequences for the restart:
   fast-forward `master` until Phase 0 is green and DB tests (Phase 4) pass.
 - **Status (post-Phase 0/2):** the split build is verified — `core` and
   `gradle-plugin` build, test (72 tests green; snapshot before the Phase 3
-  `exposed` module — see README for the current 76), and package correctly on
+  `exposed` module — see spec/README for the current 76), and package correctly on
   Java 25 and in CI; `document/` is excluded from the build. Phase 0 also proved
   the POM/publication config (PR #183) and the Groovy→Kotlin DSL migration. The
   remaining unverified risk is real-DB behavior, which Phase 4 covers.
@@ -167,7 +169,7 @@ Outcome: no dead repositories or unmaintained libraries in the build.
 Status: **merged 2026-08-01 (PRs #184-#188).** All build files now use only
 Maven Central (`document/` excluded from build). 72 tests green (68 core + 4
 gradle-plugin; Phase 0 baseline was 66; snapshot before the Phase 3 `exposed`
-module — see README for the current 76).
+module — see spec/README for the current 76).
 
 - `gradle.properties`: `kotlin_version` → 2.3.x. — **done in Phase 0** (2.3.20).
 - Dead repositories: **gone** — jcenter/bintray/space removed; jitpack removed
@@ -206,21 +208,25 @@ module — see README for the current 76).
 Outcome: `core` has zero Exposed references; users decide whether to use
 Exposed, and integration is documented. Full design: [exposed-integration.md].
 
-Status: **in progress.** PR A (2026-08-08) removed the dead `hasExposed` flag,
-exposed `jdbcConnection` on `ConnectionInterface`, and deleted
-`PluginConfig.hasExposed()`. **PR B (2026-08-09)** adds the `exposed/` module
-(`harmonica-exposed`, pinned to Exposed 0.61.0), the `exposedTransaction` bridge
-(Option A transaction ownership via a no-op commit/rollback/close proxy), and
-SQLite transaction tests covering commit, rollback, reconnect, and SQLException
-propagation through the proxy. Remaining in Phase 3: script-classpath wiring
-for `.kts` migrations (Pitfall F) and a demo project. Plan:
+Status: **merged 2026-08-09 (PRs #197, #198, #199).** `core` has zero Exposed
+references (PR A removed the dead `hasExposed` flag and exposed `jdbcConnection`
+on `ConnectionInterface`). The `exposed/` module (`harmonica-exposed`, pinned to
+Exposed 0.61.0) ships the `exposedTransaction` bridge (Option A transaction
+ownership via a no-op commit/rollback/close proxy; `WeakHashMap`-cached
+`Database` per `Connection`; `defaultMaxAttempts = 1`) with 4 SQLite tests:
+commit, rollback, reconnect, and SQLException propagation through the proxy
+(exceptions unwrapped from `InvocationTargetException` so they keep their
+`SQLException` type). **76 tests green** (68 core + 4 plugin + 4 exposed).
+Remaining in Phase 3: script-classpath wiring for `.kts` migrations (Pitfall F)
+and a demo project against a real DB (SQLite here; PostgreSQL/MySQL deferred to
+Phase 4). Plan:
 
 - Wire the script classpath so `.kts` migrations can reach `harmonica-exposed`
   and Exposed (Pitfall F: the JSR-223 engine runs on the plugin's classpath).
 - Demo project compiling a migration using the Exposed DSL and running it
   against a real DB (SQLite here; PostgreSQL/MySQL deferred to Phase 4).
-- Close issues #91, #80, and the concern behind #160 once the flow ships
-  (document, upgrade, reflect).
+- Issue #91 was closed at the merge (2026-08-09); close #80 and the concern
+  behind #160 once the flow ships (document, upgrade, reflect).
 
 ### Phase 4 — Tests & DB environment
 
@@ -245,10 +251,10 @@ Full triage: [issues-triage.md]. Order:
 1. Urgent blockers: #153 (ties into #97). #167, #165, #140, #162 are resolved
    and closed (toolchain/CI fixes in Phase 0 PR #183; README/license PR #181;
    pluralizer PR #187); #158, #159 already closed (verified; not tracked here).
-2. Small: #26 (migration file naming), #47 (prepared statements), #91
-   (Exposed), #138 (custom columns), #141 (more column types), #145 (alter
-   column), #139 (FK options), #69 (query execution API), #4
-   (created_at/updated_at), #182 (JitPack badge).
+2. Small: #26 (migration file naming), #47 (prepared statements), #138 (custom
+   columns), #141 (more column types), #145 (alter column), #139 (FK options),
+   #69 (query execution API), #4 (created_at/updated_at), #182 (JitPack badge).
+   #91 (Exposed) is **closed** — the bridge shipped in Phase 3 (PRs #197-#199).
 3. Medium: #7 (closed connection), #85 (SQLite defaults), #67 (timestamp
    default), #80 (Exposed version), #71 (seeding), #97 (JavaExec task tests),
    #155 (programmatic migration docs).


### PR DESCRIPTION
Runs the `plan-review` workflow after the Phase 3 merge (PRs #197–#199). Doc-only changes; no code.

## What changed

- **spec/plan.md**: Phase 3 status → **merged 2026-08-09 (PRs #197–#199)** with the bridge details and **76 tests green** (68 core + 4 plugin + 4 exposed); §3 `develop` ahead of `master` 56 → **75 commits**; drop `feature/mit-license` from the stale-branch list (merged via PR #166); #91 closed at the merge → removed from Phase 3 remaining work and Phase 5 small list; "see README" pointers → "see spec/README".
- **spec/issues-triage.md**: header 29 → **28 open**; #91 (closed 2026-08-09) moved from the SMALL table to Closed-but-related.
- **spec/README.md**: snapshot → 2026-08-09 after Phase 3; `setup-java@5.6.0` → `5.7.0`; "56 commits ahead" → "75 commits ahead".
- **spec/exposed-integration.md**: #91 no longer "stays open until the whole flow ships".
- **spec/ci.md**: `actions/setup-java@v5.6.0` → `v5.7.0` (PR #195) in the steps/action-policy sections and the merged-bumps list.

Verified by the `spec-review` agent against ground truth (issue states, PR merge dates, `git rev-list` count, workflow files, test counts). `./gradlew clean test` = 76, green on Java 25.