### PR TITLE
feat: fix script class path

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractMigrationTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractMigrationTask.kt
@@ -1,9 +1,12 @@
 package com.improve_future.harmonica.plugin
 
 import com.improve_future.harmonica.core.*
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
+import java.net.URLClassLoader
 import java.nio.file.Paths
 import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
@@ -13,8 +16,11 @@ abstract class AbstractMigrationTask : AbstractTask() {
     @Input
     var dbms: Dbms = Dbms.PostgreSQL
 
+    @get:Classpath
+    abstract val scriptClasspath: ConfigurableFileCollection
+
     protected fun readMigration(script: String): AbstractMigration {
-        return engine.eval(removePackageStatement(script)) as AbstractMigration
+        return evaluate(removePackageStatement(script)) as AbstractMigration
     }
 
     private fun findConfigFile(): File {
@@ -22,19 +28,47 @@ abstract class AbstractMigrationTask : AbstractTask() {
     }
 
     fun loadConfigFile(): DbConfig {
-        return engine.eval(findConfigFile().readText()) as DbConfig
+        return evaluate(findConfigFile().readText()) as DbConfig
     }
 
     protected fun createConnection(): Connection {
         return Connection(loadConfigFile())
     }
 
-    protected companion object {
-        val engine: ScriptEngine by lazy {
-            ScriptEngineManager().getEngineByName("kotlin")
-                ?: error("Kotlin script engine not found on the classpath")
-        }
+    private fun evaluate(script: String): Any = withScriptClasspath {
+        scriptEngine().eval(script)
+    }
 
+    private fun <T> withScriptClasspath(block: () -> T): T {
+        val previous = Thread.currentThread().contextClassLoader
+        Thread.currentThread().contextClassLoader = scriptClassLoader()
+        return try {
+            block()
+        } finally {
+            Thread.currentThread().contextClassLoader = previous
+        }
+    }
+
+    private var scriptClassLoader: URLClassLoader? = null
+
+    private fun scriptClassLoader(): URLClassLoader {
+        scriptClassLoader?.let { return it }
+        val parent = AbstractMigrationTask::class.java.classLoader
+        val urls = scriptClasspath.files.map { it.toURI().toURL() }.toTypedArray()
+        return URLClassLoader(urls, parent).also { scriptClassLoader = it }
+    }
+
+    private var scriptEngine: ScriptEngine? = null
+
+    private fun scriptEngine(): ScriptEngine {
+        scriptEngine?.let { return it }
+        val engine = ScriptEngineManager().getEngineByName("kotlin")
+            ?: error("Kotlin script engine not found on the classpath")
+        scriptEngine = engine
+        return engine
+    }
+
+    protected companion object {
         protected fun removePackageStatement(script: String) =
             script.replace(Regex("^\\s*package\\s+.+"), "")
     }

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/HarmonicaPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/HarmonicaPlugin.kt
@@ -6,19 +6,31 @@ import org.gradle.api.Project
 
 open class HarmonicaPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.tasks.register("harmonicaUp", MigrationUpTask::class.java) { task ->
-            task.group = PluginConfig.groupName
-            task.description = "Migrate up."
+        val scriptClasspath = project.configurations.create("harmonica") {
+            it.isCanBeConsumed = false
+            it.isCanBeResolved = true
         }
+
+        fun registerMigrationTask(
+            name: String, description: String, type: Class<out AbstractMigrationTask>
+        ) {
+            project.tasks.register(name, type) { task ->
+                task.group = PluginConfig.groupName
+                task.description = description
+                task.scriptClasspath.from(scriptClasspath)
+            }
+        }
+
+        registerMigrationTask(
+            "harmonicaUp", "Migrate up.", MigrationUpTask::class.java
+        )
+        registerMigrationTask(
+            "harmonicaDown", "Migrate down.", MigrationDownTask::class.java
+        )
 
         project.tasks.register("harmonicaCreate", MigrationCreate::class.java) { task ->
             task.group = PluginConfig.groupName
             task.description = "Create migration file."
-        }
-
-        project.tasks.register("harmonicaDown", MigrationDownTask::class.java) { task ->
-            task.group = PluginConfig.groupName
-            task.description = "Migrate down."
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/MigrationDownTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/MigrationDownTask.kt
@@ -6,7 +6,7 @@ import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 @DisableCachingByDefault(because = "Migration tasks execute user-provided scripts")
-open class MigrationDownTask : AbstractMigrationTask() {
+abstract class MigrationDownTask : AbstractMigrationTask() {
     @TaskAction
     fun migrateDown() {
         val connection = createConnection()

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/MigrationUpTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/MigrationUpTask.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
 @DisableCachingByDefault(because = "Migration tasks execute user-provided scripts")
-open class MigrationUpTask : AbstractMigrationTask() {
+abstract class MigrationUpTask : AbstractMigrationTask() {
     @TaskAction
     fun migrateUp() {
         val connection = createConnection()

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/ScriptClasspathTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/ScriptClasspathTest.kt
@@ -18,6 +18,7 @@ class ScriptClasspathTest {
         }
         val markerFile = File(workDir, "touched")
         val classesDir = compileScriptProbe(workDir)
+        val markerPath = markerFile.invariantSeparatorsPath
 
         val migration = createMigrationTask(classesDir).evalScript(
             """
@@ -26,7 +27,7 @@ class ScriptClasspathTest {
 
             object : AbstractMigration() {
                 override fun up() {
-                    ScriptProbe.touch("${markerFile.absolutePath}")
+                    ScriptProbe.touch("$markerPath")
                 }
             }
             """.trimIndent()

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/ScriptClasspathTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/ScriptClasspathTest.kt
@@ -1,0 +1,100 @@
+package com.improve_future.harmonica.plugin
+
+import com.improve_future.harmonica.core.AbstractMigration
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import java.io.File
+import javax.tools.ToolProvider
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ScriptClasspathTest {
+    @Test
+    fun scriptCanUseClassesFromTheHarmonicaConfiguration() {
+        val workDir = File.createTempFile("harmonica-script-classpath", "").let {
+            it.delete()
+            it.mkdirs()
+            it
+        }
+        val markerFile = File(workDir, "touched")
+        val classesDir = compileScriptProbe(workDir)
+
+        val migration = createMigrationTask(classesDir).evalScript(
+            """
+            import com.improve_future.harmonica.core.AbstractMigration
+            import scriptprobe.ScriptProbe
+
+            object : AbstractMigration() {
+                override fun up() {
+                    ScriptProbe.touch("${markerFile.absolutePath}")
+                }
+            }
+            """.trimIndent()
+        )
+        migration.up()
+
+        assertTrue(markerFile.exists())
+    }
+
+    @Test
+    fun scriptWithoutExtraClasspathFailsToResolveScriptProbe() {
+        val task = createMigrationTask(null)
+        assertFailsWith<Exception> {
+            task.evalScript(
+                """
+                import com.improve_future.harmonica.core.AbstractMigration
+                import scriptprobe.ScriptProbe
+
+                object : AbstractMigration() {
+                    override fun up() {
+                        ScriptProbe.touch("/tmp/harmonica-should-not-exist")
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun createMigrationTask(scriptClasspath: File?): ProbeMigrationTask {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.create("probe", ProbeMigrationTask::class.java)
+        scriptClasspath?.let { task.scriptClasspath.from(it) }
+        return task
+    }
+
+    private fun compileScriptProbe(workDir: File): File {
+        val source = File(workDir, "scriptprobe/ScriptProbe.java").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package scriptprobe;
+
+                import java.io.File;
+                import java.io.IOException;
+
+                public class ScriptProbe {
+                    public static void touch(String path) throws IOException {
+                        File file = new File(path);
+                        file.getParentFile().mkdirs();
+                        if (!file.createNewFile()) {
+                            throw new IOException("already exists: " + path);
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+        val classesDir = File(workDir, "classes").apply { mkdirs() }
+        val compiler = ToolProvider.getSystemJavaCompiler()
+        val result = compiler.run(
+            null, null, null,
+            "-d", classesDir.absolutePath, source.absolutePath
+        )
+        check(result == 0) { "Failed to compile ScriptProbe" }
+        return classesDir
+    }
+}
+
+abstract class ProbeMigrationTask : AbstractMigrationTask() {
+    fun evalScript(script: String): AbstractMigration = readMigration(script)
+}

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -206,11 +206,29 @@ transaction.**
   `closeAndUnregister` is not called (core purity, above).
 - **Script classpath (Pitfall F)**: migration `.kts` files are evaluated by the
   Gradle plugin's JSR-223 engine on the **plugin's classpath**
-  (`AbstractMigrationTask.kt:33-37`). Adding `harmonica-exposed` via the user's
+  (`AbstractMigrationTask.kt`). Adding `harmonica-exposed` via the user's
   `implementation(...)` is not enough — the bridge/Exposed must be reachable by
-  the script engine. Options: a plugin-managed configuration appended to the
-  script classpath, or `buildscript { dependencies { classpath(...) } }`.
-  Design this explicitly in Phase 3.
+  the script engine. **Resolved design (Phase 3)**: the `harmonica` plugin
+  creates a resolvable, non-consumable `harmonica` configuration and wires it
+  into the up/down tasks' `scriptClasspath` (`@Classpath` `ConfigurableFileCollection`
+  on `AbstractMigrationTask`). At evaluation time the task builds a
+  `URLClassLoader` over the configuration's resolved files (parent = plugin
+  classloader) and sets it as the thread context classloader before first use of
+  the JSR-223 engine — the Kotlin engine derives script dependencies from that
+  context classloader (`KotlinJsr223DefaultScriptEngineFactory`
+  `dependenciesFromCurrentContext`). Because the classpath is captured at engine
+  creation, the engine is created per task instance (not the previous
+  classloader-wide singleton). Usage:
+
+  ```kotlin
+  plugins { id("harmonica") }
+  dependencies {
+      harmonica("com.improve_future.harmonica:harmonica-exposed:2.0.0")
+  }
+  ```
+
+  The `jarmonica` plugin needs no equivalent: its forked JVM already runs on the
+  project's `runtimeClasspath`, so `implementation(...)` suffices there.
 
 ### 3. No `Class.forName` special-casing in core
 
@@ -266,9 +284,13 @@ its `SQLException` type instead of surfacing as
 `UndeclaredThrowableException`). Full `./gradlew build` is green with and
 without Exposed on the classpath; `:core` still has zero Exposed references.
 
-**Remaining for Phase 3:** script-classpath wiring for `.kts` migrations
-(Pitfall F) and the demo project against a real DB (SQLite here; PostgreSQL/MySQL
-deferred to Phase 4 integration tests).
+**Shipped in Phase 3:** script-classpath wiring for `.kts` migrations
+(Pitfall F) — the `harmonica` plugin-managed configuration above
+(`ScriptClasspathTest` proves a migration `.kts` can resolve a class that lives
+only on that configuration and fails without it).
+
+**Remaining for Phase 3:** the demo project against a real DB (SQLite here;
+PostgreSQL/MySQL deferred to Phase 4 integration tests).
 
 ## Open questions
 


### PR DESCRIPTION
This pull request implements robust script classpath handling for migration tasks in the Harmonica Gradle plugin. Migration scripts (`.kts`) can now reliably resolve classes provided via a dedicated, plugin-managed configuration, ensuring that all dependencies required by migration scripts are available at runtime. The changes also include comprehensive tests to verify this behavior.

**Script classpath management improvements:**

- Introduced a `@Classpath`-annotated `ConfigurableFileCollection` property (`scriptClasspath`) on `AbstractMigrationTask`, and logic to create a `URLClassLoader` from its contents, ensuring migration scripts are evaluated with all required dependencies available. The script engine is now instantiated per task instance using this classloader. [[1]](diffhunk://#diff-a0f4369cff641fdcf8d788dcb215e446128e243847a5627c4903fa16d81da828R4-R9) [[2]](diffhunk://#diff-a0f4369cff641fdcf8d788dcb215e446128e243847a5627c4903fa16d81da828R19-R71)
- The `HarmonicaPlugin` now creates a resolvable, non-consumable `harmonica` configuration and wires it into the `scriptClasspath` of migration tasks (`harmonicaUp`, `harmonicaDown`), ensuring user-supplied dependencies are available to scripts.

**Testing:**

- Added `ScriptClasspathTest` to verify that migration scripts can resolve and use classes provided only via the `harmonica` configuration, and that missing classpath entries cause expected failures.

**Documentation:**

- Updated `spec/exposed-integration.md` to describe the new script classpath wiring design, usage instructions, and to confirm that this feature is shipped in Phase 3. [[1]](diffhunk://#diff-ea5dbab4d68464b5f257ba492cccf2affd6e097fd33d9586d4e81a1682a7b87eL209-R231) [[2]](diffhunk://#diff-ea5dbab4d68464b5f257ba492cccf2affd6e097fd33d9586d4e81a1682a7b87eL269-R293)

**Other:**

- Changed `MigrationUpTask` and `MigrationDownTask` from `open` to `abstract` to better support test subclassing and plugin extensibility. [[1]](diffhunk://#diff-16c46fe5192d37ca4fbe8e3644e9688a00830471b94d2d6c0350758aeb7ae1e4L8-R8) [[2]](diffhunk://#diff-dc4b56882aa92df882fe762fdbb4feb6d83b7d9b9061ff97cc618981f4149558L9-R9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration scripts can now use dependencies added through the plugin’s dedicated `harmonica` configuration.
  * Script dependencies are correctly available during migration execution.

* **Documentation**
  * Updated integration documentation with script-classpath setup instructions and current feature status.

* **Tests**
  * Added coverage confirming scripts resolve configured dependencies and fail appropriately without them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->