### PR TITLE
Add bin/gw token-saving Gradle wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,10 @@ and is being restarted. See `spec/plan.md` for the master plan.
 
 ## Conventions
 
-- Use `bin/gw` to run Gradle (plain console, output trimmed to ~60 lines) instead
-  of `./gradlew`; it saves output tokens. Use `./gradlew` directly when full
+- Use `bin/gw` to run Gradle for the root build (plain console, output trimmed
+  to ~60 lines) instead of `./gradlew`; it saves output tokens. `bin/gw` changes
+  to the repository root, so it cannot run tasks of the nested `document/`
+  build — use `document/gradlew` there. Use `./gradlew` directly when full
   output is needed.
 - Follow existing code style; do not add comments unless asked.
 - Do not add dependencies that are not actually used (there is a history of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ and is being restarted. See `spec/plan.md` for the master plan.
 
 ## Conventions
 
+- Use `bin/gw` to run Gradle (plain console, output trimmed to ~60 lines) instead
+  of `./gradlew`; it saves output tokens. Use `./gradlew` directly when full
+  output is needed.
 - Follow existing code style; do not add comments unless asked.
 - Do not add dependencies that are not actually used (there is a history of
   unused deps: `commons-codec`, `kotlin-reflect`, `kotlinx-html-jvm` in the

--- a/bin/gw
+++ b/bin/gw
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# gw: run a Gradle task with plain console and trimmed output (token saver)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+./gradlew --console=plain "$@" 2>&1 | tail -n "${GW_TAIL_LINES:-60}"


### PR DESCRIPTION
Adds `bin/gw`, a wrapper that runs Gradle with plain console and trims output to ~60 lines to save agent tokens, and documents it in AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a convenient command for running Gradle builds with concise, plain-text output.
  - Gradle output is limited to the most recent 60 lines by default, with an option to retain full output.
  - Added repository guidance for choosing between concise and full Gradle output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->