### PR TITLE
Reconcile spec docs with direct scripting host (plan-review)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,7 @@ and is being restarted. See `spec/plan.md` for the master plan.
 ## Layout
 
 - `core/` — the migration library (JDBC, no Exposed dependency).
-- `gradle-plugin/` — Gradle plugin + JSR-223 script engine for `.kts`
-  migrations.
+- `gradle-plugin/` — Gradle plugin + scripting host for `.kts` migrations.
 - `document/` — nested standalone Gradle build (site generator), stale.
 - `spec/` — planning docs; the source of truth for the restart. Read them
   before proposing work; update them when decisions change.

--- a/spec/README.md
+++ b/spec/README.md
@@ -16,21 +16,28 @@ plan to restart and modernize the project.
 
 ## Current state (baseline, branch `develop`)
 
-> Snapshot taken 2026-08-09, after Phase 3 (Exposed bridge, PRs #197-#199).
+> Snapshot taken 2026-08-12, after Phase 3 (Exposed bridge, PRs #197-#199;
+> script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203).
 > Update this list when the baseline advances.
 
 - Kotlin **2.3.20**, Gradle wrapper **9.6.1**, `jvmTarget = 1.8` (class-file
   major 52 asserted in CI)
 - Gradle plugin-publish **2.1.1**, Dokka **2.2.0** (Dokka bundles Jackson
   2.15.3 at build time only — not shipped; see the Dependabot alerts)
-- Publish target: plugin-publish + OSSRH staging (jcenter/bintray removed)
+- Publish target: plugin-publish + OSSRH staging (jcenter/bintray removed);
+  JitPack vs Maven Central decision still open (plan.md §6) — OSSRH is Phase 6
+  prep
 - CI: GitHub Actions only — `ci.yml` (PR/push, Temurin JDK 25,
   `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
   `actions/setup-java@5.7.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (Dependabot). CircleCI removed.
-- Three active modules: `core`, `exposed`, `gradle-plugin` — **76 tests green**
-  (68 core + 4 plugin + 4 exposed); `document` (nested standalone build) is
+- Three active modules: `core`, `exposed`, `gradle-plugin` — **78 tests green**
+  (68 core + 6 plugin + 4 exposed); `document` (nested standalone build) is
   excluded from the build
+- Migration `.kts` scripts are compiled/evaluated with a direct
+  `BasicJvmScriptingHost` from a `MigrationScript` `@KotlinScript` template
+  (PR #202) — no JSR-223 engine — over the plugin's `harmonica` configuration
+  classpath (PR #201)
 - License headers stripped from all source files (PR #180); README badges fixed
   (PR #181)
 - No Exposed dependency in `core`. The optional `harmonica-exposed` module
@@ -40,7 +47,7 @@ plan to restart and modernize the project.
   [`exposed-integration.md`](exposed-integration.md)
 - Tests for real DBMS still live in the separate `harmonica_test` repository —
   to be merged in Phase 4
-- **`develop` is 75 commits ahead of `master`** — Phase 4 (real-DB tests) must
+- **`develop` is 83 commits ahead of `master`** — Phase 4 (real-DB tests) must
   pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 
 ## Machine environment (current)

--- a/spec/README.md
+++ b/spec/README.md
@@ -16,7 +16,7 @@ plan to restart and modernize the project.
 
 ## Current state (baseline, branch `develop`)
 
-> Snapshot taken 2026-08-12, after Phase 3 (Exposed bridge, PRs #197-#199;
+> Snapshot taken 2026-08-11, after Phase 3 (Exposed bridge, PRs #197-#199;
 > script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203).
 > Update this list when the baseline advances.
 

--- a/spec/exposed-integration.md
+++ b/spec/exposed-integration.md
@@ -1,11 +1,13 @@
 # Exposed Optionality — Design
 
-> **Status: shipped in part (2026-08-09, PR B).** The `exposed/` module
-> (artifact `harmonica-exposed`), the `exposedTransaction` bridge, and embedded
-> SQLite transaction tests (commit + rollback + reconnect + SQLException
-> propagation) exist and pass (`./gradlew :exposed:test`, 4 tests). Still open
-> in Phase 3: script-classpath wiring for `.kts` migrations (Pitfall F) and a
-> demo project. Issue #91 was closed at the Phase 3 merge (2026-08-09).
+> **Status: shipped (2026-08-09 PR B, wiring 2026-08-11 PRs #201/#202).** The
+> `exposed/` module (artifact `harmonica-exposed`), the `exposedTransaction`
+> bridge, and embedded SQLite transaction tests (commit + rollback + reconnect +
+> SQLException propagation) exist and pass (`./gradlew :exposed:test`, 4
+> tests). Script-classpath wiring for `.kts` migrations (Pitfall F) is **done**
+> — the plugin evaluates scripts via a direct `BasicJvmScriptingHost` over the
+> `harmonica` configuration. Still open in Phase 3: the demo project. Issue #91
+> was closed at the Phase 3 merge (2026-08-09).
 
 ## Problem
 
@@ -205,20 +207,21 @@ transaction.**
   `Database.connect`) in the same JVM. The previous manager is not restored and
   `closeAndUnregister` is not called (core purity, above).
 - **Script classpath (Pitfall F)**: migration `.kts` files are evaluated by the
-  Gradle plugin's JSR-223 engine on the **plugin's classpath**
+  Gradle plugin's script host on the **plugin's classpath**
   (`AbstractMigrationTask.kt`). Adding `harmonica-exposed` via the user's
   `implementation(...)` is not enough — the bridge/Exposed must be reachable by
-  the script engine. **Resolved design (Phase 3)**: the `harmonica` plugin
-  creates a resolvable, non-consumable `harmonica` configuration and wires it
-  into the up/down tasks' `scriptClasspath` (`@Classpath` `ConfigurableFileCollection`
-  on `AbstractMigrationTask`). At evaluation time the task builds a
-  `URLClassLoader` over the configuration's resolved files (parent = plugin
-  classloader) and sets it as the thread context classloader before first use of
-  the JSR-223 engine — the Kotlin engine derives script dependencies from that
-  context classloader (`KotlinJsr223DefaultScriptEngineFactory`
-  `dependenciesFromCurrentContext`). Because the classpath is captured at engine
-  creation, the engine is created per task instance (not the previous
-  classloader-wide singleton). Usage:
+  the script compiler/runtime. **Resolved design (Phase 3)**: the `harmonica`
+  plugin creates a resolvable, non-consumable `harmonica` configuration and
+  wires it into the up/down tasks' `scriptClasspath` (`@Classpath`
+  `ConfigurableFileCollection` on `AbstractMigrationTask`). At evaluation time
+  the task builds a `URLClassLoader` over the configuration's resolved files
+  (parent = plugin classloader) and sets it as the thread context classloader,
+  then evaluates the script **directly** with `BasicJvmScriptingHost`
+  (`kotlin.script.experimental.jvmhost`) — the `MigrationScript` `@KotlinScript`
+  template is compiled via `createJvmCompilationConfigurationFromTemplate` with
+  `dependenciesFromCurrentContext(wholeClasspath = true)`, so script
+  dependencies are derived from that context classloader. This replaced the
+  JSR-223 engine (PR #202; the config is cached per task instance). Usage:
 
   ```kotlin
   plugins { id("harmonica") }
@@ -313,4 +316,5 @@ Resolved (2026-08-09, PR B):
 
 Remaining:
 
-- Script classpath wiring for `.kts` migrations (Pitfall F).
+- Demo project against a real DB (SQLite here; PostgreSQL/MySQL deferred to
+  Phase 4) — built locally, not yet merged.

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-09 (**28 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-12 (**28 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 
@@ -67,9 +67,9 @@ superseded by Phase 0.
 
 - #91 (closed 2026-08-09 at the Phase 3 merge, PRs #197-#199): "Exposed Library
   must be loaded by Class.forName" — `core` has no Exposed reference and the
-  `harmonica-exposed` bridge shipped. Script-classpath wiring (Pitfall F) and
-  the demo project remain as Phase 3 work, tracked by [plan.md](plan.md), not by
-  this issue.
+  `harmonica-exposed` bridge shipped. Script-classpath wiring (Pitfall F)
+  shipped 2026-08-11 (PRs #201/#202); the demo project remains as Phase 3 work,
+  tracked by [plan.md](plan.md), not by this issue.
 - #168 (PR, merged): bug-build-issue — build fixes already on `develop`.
 - #160 (closed): "How it should be used with Exposed" — reopened conceptually in
   exposed-integration.md.

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-12 (**28 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-11 (**28 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -34,7 +34,7 @@ State:
 
 - `master` (origin/master @ `3b423c6`) has not been touched in years and is the
   direct ancestor of `develop` (merge-base == master HEAD).
-- `develop` is **75 commits ahead** (module split into `core`/`gradle-plugin`,
+- `develop` is **83 commits ahead** (module split into `core`/`gradle-plugin`,
   jcenter removal work, MIT license change, CI-action bumps, Phase 3 Exposed
   bridge, etc.) but **never fully tested or released** — this is why master was
   left behind.
@@ -78,7 +78,7 @@ Consequences for the restart:
   fast-forward `master` until Phase 0 is green and DB tests (Phase 4) pass.
 - **Status (post-Phase 0/2):** the split build is verified — `core` and
   `gradle-plugin` build, test (72 tests green; snapshot before the Phase 3
-  `exposed` module — see spec/README for the current 76), and package correctly on
+  `exposed` module — see spec/README for the current 78), and package correctly on
   Java 25 and in CI; `document/` is excluded from the build. Phase 0 also proved
   the POM/publication config (PR #183) and the Groovy→Kotlin DSL migration. The
   remaining unverified risk is real-DB behavior, which Phase 4 covers.
@@ -123,7 +123,9 @@ Status: **implemented and merged (2026-08-01, PR #183, merge commit
   `javax.script.ScriptEngine` + `getEngineByName("kotlin")`, and the plugin's
   committed `META-INF/services/javax.script.ScriptEngineFactory` was **deleted**
   (it pointed at the removed `org.jetbrains.kotlin.script.jsr223.*` factory; the
-  dependency registers its own).
+  dependency registers its own). **Superseded 2026-08-11 (PR #202):** the
+  JSR-223 engine was replaced by a direct `BasicJvmScriptingHost` — see the
+  decision in §6 and Phase 3 status.
 - **Coordinates/IDs**: still open. The legacy `pluginBundle` block (published
   id `com.improve_future.harmonica`) was removed by the plugin-publish 2.x
   migration; applied/published ids are now `harmonica`/`jarmonica`. The stale
@@ -168,8 +170,8 @@ Outcome: no dead repositories or unmaintained libraries in the build.
 
 Status: **merged 2026-08-01 (PRs #184-#188).** All build files now use only
 Maven Central (`document/` excluded from build). 72 tests green (68 core + 4
-gradle-plugin; Phase 0 baseline was 66; snapshot before the Phase 3 `exposed`
-module — see spec/README for the current 76).
+gradle-plugin; Phase 0 baseline was 66; `ScriptClasspathTest` later added 2
+plugin tests (PR #201) — see spec/README for the current 78).
 
 - `gradle.properties`: `kotlin_version` → 2.3.x. — **done in Phase 0** (2.3.20).
 - Dead repositories: **gone** — jcenter/bintray/space removed; jitpack removed
@@ -183,7 +185,8 @@ module — see spec/README for the current 76).
     `kotlin-test` → current (**done in Phase 0**, pinned to 2.3.20).
 - `gradle-plugin`:
   - `kotlin-script-runtime`/`kotlin-script-util` → `kotlin-scripting-jsr223` —
-    **done in Phase 0** (JSR-223 migration).
+    **done in Phase 0** (JSR-223 migration); **superseded 2026-08-11 (PR #202)**
+    by the direct `BasicJvmScriptingHost` — see Phase 3 status and §6.
   - `org.reflections` 0.9.11 → **replaced** with a lightweight classpath
     scanner in `JarmonicaTaskMain` (PR #185; `loadClass` narrowed to
     recoverable exceptions in PR #188 — remaining `isSubtypeOf` `catch
@@ -216,13 +219,20 @@ ownership via a no-op commit/rollback/close proxy; `WeakHashMap`-cached
 `Database` per `Connection`; `defaultMaxAttempts = 1`) with 4 SQLite tests:
 commit, rollback, reconnect, and SQLException propagation through the proxy
 (exceptions unwrapped from `InvocationTargetException` so they keep their
-`SQLException` type). **76 tests green** (68 core + 4 plugin + 4 exposed).
-Remaining in Phase 3: script-classpath wiring for `.kts` migrations (Pitfall F)
-and a demo project against a real DB (SQLite here; PostgreSQL/MySQL deferred to
-Phase 4). Plan:
+`SQLException` type). **78 tests green** (68 core + 6 plugin + 4 exposed).
+Script-classpath wiring for `.kts` migrations (Pitfall F) shipped **2026-08-11
+(PRs #201, #202)**: the plugin evaluates `.kts` scripts directly with
+`BasicJvmScriptingHost` from a `MigrationScript` `@KotlinScript` template (no
+JSR-223 engine), and `ScriptClasspathTest` (2 tests) covers the classpath.
+Remaining in Phase 3: a demo project against a real DB (SQLite here;
+PostgreSQL/MySQL deferred to Phase 4) — built locally but not yet merged.
+Plan:
 
 - Wire the script classpath so `.kts` migrations can reach `harmonica-exposed`
-  and Exposed (Pitfall F: the JSR-223 engine runs on the plugin's classpath).
+  and Exposed (Pitfall F) — **DONE** (PRs #201/#202; the direct scripting host
+  loads the base class from the plugin classloader and derives script
+  dependencies from the thread context classloader over the `harmonica`
+  configuration).
 - Demo project compiling a migration using the Exposed DSL and running it
   against a real DB (SQLite here; PostgreSQL/MySQL deferred to Phase 4).
 - Issue #91 was closed at the merge (2026-08-09); close #80 and the concern
@@ -341,3 +351,12 @@ Resolved for Phase 3 (2026-08-08):
   forbids a close hook), so it must not be combined with other Exposed code
   (bare `transaction {}`, another `Database.connect`) in a shared JVM. See
   exposed-integration.md §2.2.
+
+Resolved (2026-08-11):
+
+- Script engine: **direct `BasicJvmScriptingHost`**, not the JSR-223 engine
+  (PR #202). `.kts` migrations compile/evaluate via a `MigrationScript`
+  `@KotlinScript` template using `createJvmCompilationConfigurationFromTemplate`
+  + `dependenciesFromCurrentContext(wholeClasspath = true)`; `kotlin-scripting-common`
+  / `kotlin-scripting-jvm` / `kotlin-scripting-jvm-host` replace
+  `kotlin-scripting-jsr223`. See tech-notes.md.

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,6 +1,6 @@
 # Toolchain & Dependency Research
 
-Facts gathered on 2026-08-01 (test counts updated 2026-08-12). Update this
+Facts gathered on 2026-08-01 (test counts updated 2026-08-11). Update this
 file as versions change.
 
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,15 +1,15 @@
 # Toolchain & Dependency Research
 
-Facts gathered on 2026-08-01 (test counts updated 2026-08-09). Update this
+Facts gathered on 2026-08-01 (test counts updated 2026-08-12). Update this
 file as versions change.
 
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **76 unit tests pass (68 core,
-  4 gradle-plugin, 4 exposed), 0 failures/errors** (Phase 0 baseline was 66;
-  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 4 ExposedMigrationTest
-  cases).
+  `./gradlew clean build` is green on Java 25; **78 unit tests pass (68 core,
+  6 gradle-plugin, 4 exposed), 0 failures/errors** (Phase 0 baseline was 66;
+  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 4
+  ExposedMigrationTest cases; PR #201 added 2 ScriptClasspathTest cases).
 - `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
   + `java.sourceCompatibility/targetCompatibility = 1.8` in all three modules
   (`core`, `exposed`, `gradle-plugin`). Verified by `javap`: all main classes are
@@ -59,7 +59,7 @@ Key references:
 | Dependency | Status | Notes |
 | --- | --- | --- |
 | `kotlin-compiler-embeddable` | **DONE** | 2.3.20. |
-| `kotlin-script-runtime` / `kotlin-script-util` → `kotlin-scripting-jsr223` | **DONE** | `kotlin-script-util` does not exist for 2.3.20 (404; Maven Central metadata frozen at 1.8.22). The JSR-223 engine moved to `kotlin.script.experimental.jsr223`; the plugin's committed `META-INF/services/javax.script.ScriptEngineFactory` was **deleted** (pointed at the removed `org.jetbrains.kotlin.script.jsr223.*` class; the dependency registers its own factory). `AbstractMigrationTask` now uses `javax.script.ScriptEngine` + `getEngineByName("kotlin")`. |
+| `kotlin-script-runtime` / `kotlin-script-util` → `kotlin-scripting-jvm-host` | **DONE** | `kotlin-script-util` does not exist for 2.3.20 (404; Maven Central metadata frozen at 1.8.22), so Phase 0 adopted `kotlin-scripting-jsr223`. **Replaced 2026-08-11 (PR #202)** by `kotlin-scripting-common` + `kotlin-scripting-jvm` + `kotlin-scripting-jvm-host`: `AbstractMigrationTask` evaluates `.kts` directly with `BasicJvmScriptingHost` from a `MigrationScript` `@KotlinScript` template (`createJvmCompilationConfigurationFromTemplate`, `dependenciesFromCurrentContext(wholeClasspath = true)`, base class loaded from the plugin classloader); no `javax.script.ScriptEngine` / registered `ScriptEngineFactory` anymore. |
 | `kotlin-reflect` | **DONE** | dropped — only stdlib `KClass` usage (PR #184). |
 | `org.reflections:reflections` | **DONE** | replaced with a classpath scanner in `JarmonicaTaskMain` (Phase 2, PRs #185/#188). |
 | `kotlinx-html-jvm` | **DONE** | dropped here (PR #184); real consumer is `document` (Phase 7). |


### PR DESCRIPTION
Post-merge reconciliation after PRs #201/#202/#203.

- Test counts 76 \u2192 **78** (68 core + 6 plugin + 4 exposed; +2 ScriptClasspathTest from #201) across plan.md, tech-notes.md, spec/README.md
- JSR-223 \u2192 direct `BasicJvmScriptingHost` (PR #202): Phase 0/2 notes marked superseded, new \u00a76 decision block, tech-notes dependency row, exposed-integration Pitfall F mechanism, AGENTS.md layout line
- Phase 3 status: Pitfall F wiring marked DONE; demo project remains
- `develop` ahead-of-`master` count 75 \u2192 83
- issues-triage.md snapshot 2026-08-12 (28 open, unchanged)

Verified: 0 blockers / 3 warnings fixed per spec-review agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation to reflect the latest scripting workflow for Kotlin migration scripts.
  - Marked script-classpath support as shipped and clarified remaining Phase 3 work.
  - Refreshed status dates, progress metrics, test counts, and release-readiness notes.
  - Documented updated publishing plans and recent tooling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->