### PR TITLE
docs: detail Phase 4 breakdown

### DIFF
--- a/spec/ci.md
+++ b/spec/ci.md
@@ -61,10 +61,14 @@ As landed:
     `dependency-graph: generate-and-upload` (+
     `dependency-graph-continue-on-failure: true`) so Dependabot PRs resolve
     against an up-to-date dependency graph.
-  - `./gradlew build --no-daemon` (unit tests only by default; DB-gated tests
-    excluded — see `spec/testing.md`).
+  - `./gradlew build --no-daemon` (unit tests plus always-green embedded SQLite
+    tests; DB-gated PostgreSQL/MySQL tests excluded — see `spec/testing.md`).
 - **Matrix (later, Phase 4)**: a `db-integration` job with `postgres:16` /
-  `mysql:8` service containers running the gated integration suite.
+  `mysql:8` service containers running the gated integration suite in
+  **required** mode: `HARMONICA_TEST_DB_REQUIRED` set only in CI makes the
+  connectivity probe bounded-retry and **fails** on invalid configuration,
+  missing credentials, unavailable services, or skipped DB tests — never skips
+  (see `spec/testing.md`).
 
 ### 3.2 `jvm8-bytecode.yml` — prove JVM 8 target without JDK 8
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -232,17 +232,43 @@ Phase 4). Plan:
 
 Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
 
-- Merge relevant tests from `KenjiOhtsuka/harmonica_test` into a new
-  `integration-test` module or a dedicated source set.
-- Local DBs: install Docker (or use system Postgres/MySQL) and document setup;
-  provide `docker-compose.yml` for PostgreSQL/MySQL; SQLite and H2 need no
-  server and **will be covered** by Docker-free embedded-DB tests (see
-  [`testing.md`](testing.md)).
-- Tests that need a DB are gated (skip when DB unavailable) so `./gradlew build`
-  never fails locally without Docker.
-- CI runs DB-backed tests using Docker services.
-- Decide test framework/tooling (**JUnit 6.x** — used in `core`/`gradle-plugin`
-  since Phase 2, PR #186 — plus Testcontainers for PostgreSQL/MySQL).
+**Status: in progress (2026-08-12).** Docker installed on the dev machine.
+Breakdown (each item is its own small PR against `develop`):
+
+1. **Integration module scaffold** (`integration-test` subproject, per
+   [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`; DB config from
+   env vars (`HARMONICA_TEST_DB_URL` etc.) with a short-timeout connectivity
+   probe in `@BeforeAll` → `Assumptions.abort` (tests **skip**, never fail).
+   Default `build` runs unit tests only; the DB suite runs via a separate
+   `integrationTest` task / `-PwithDb`.
+2. **Port `harmonica_test`** — the 4 migrations (normal/not-null/default/other)
+   and Postgres/MySql/Sqlite configs move in as JVM-level JDBC assertions
+   (table/columns/index/data) after `Connection.transaction { up() }` / `down()`.
+   SQLite is always-green (embedded); PostgreSQL/MySQL run when available.
+3. **H2 embedded path** — add `Dbms.H2` connection-URI support to `core`
+   (currently returns `""`; `SqlServerAdapter` stays TODO, Phase 5) + H2 test
+   driver. Second Docker-free DBMS alongside SQLite.
+4. **Plugin-flow tests (issue #196)** — Gradle TestKit runs the `harmonica`
+   up/down tasks against a real DB **with and without** `harmonica-exposed` on
+   the script classpath. Seeds from the local `demo/` scratch project (rewritten
+   for the direct scripting host), which gets committed here.
+5. **Docker + CI** — `docker-compose.yml` at the repo root (postgres:16,
+   mysql:8, `developer`/`developer`, DB `harmonica_test`); a `db-integration`
+   CI job runs the gated suite against Postgres/MySQL service containers (see
+   [`ci.md`](ci.md) §3.1); SQLite/H2 stay in the fast path.
+
+Test framework/tooling decision: **JUnit 6.x** (in `core`/`gradle-plugin` since
+Phase 2, PR #186). Testcontainers optional later; env-var config + compose
+services are the baseline so the suite runs without container APIs.
+
+Definition of done:
+
+- `integration-test` module exists in this repo, ported from `harmonica_test`.
+- `./gradlew build` passes without Docker; `integrationTest` passes with it.
+- SQLite + H2 real-DB tests are part of the always-on fast path.
+- Postgres + MySQL suites green locally (Docker) and in CI (service containers).
+- Issue #196 satisfied — the migration flow is verified with and without
+  `harmonica-exposed` on the classpath.
 
 ### Phase 5 — Issue backlog (quick wins first)
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -25,7 +25,8 @@ several years. This plan is the single source of truth for the restart.
   1.8` bytecode remains supported — verified in Phase 0 with no deprecation
   warning under 2.3.20 (only the old `kotlinOptions` DSL is deprecated, which
   this build doesn't use).
-- No Docker installed locally (yet). DB-backed tests must not break local builds.
+- Docker/Compose is a dev+CI dependency (Phase 4, item 5) — DB-backed tests
+  must not break local builds when the daemon is absent.
 - Do not force Exposed onto users; their migration classpath decides.
 
 ## 3. Branch & release strategy (master is stale)
@@ -232,30 +233,51 @@ Phase 4). Plan:
 
 Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
 
-**Status: in progress (2026-08-12).** Docker installed on the dev machine.
+**Status: in progress (2026-08-11).** Docker/Compose is a reproducible dev+CI
+dependency (item 5, [`ci.md`](ci.md) §3.1), not a machine-local detail.
 Breakdown (each item is its own small PR against `develop`):
 
 1. **Integration module scaffold** (`integration-test` subproject, per
-   [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`; DB config from
-   env vars (`HARMONICA_TEST_DB_URL` etc.) with a short-timeout connectivity
-   probe in `@BeforeAll` → `Assumptions.abort` (tests **skip**, never fail).
-   Default `build` runs unit tests only; the DB suite runs via a separate
-   `integrationTest` task / `-PwithDb`.
+   [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`.
+   - Connection info from env vars with known local defaults; precedence is
+     env-var > default:
+     - PostgreSQL — `HARMONICA_TEST_POSTGRES_HOST`/`_PORT`/`_DB`/`_USER`/
+       `_PASSWORD` → `127.0.0.1`/`5432`/`harmonica_test`/`developer`/`developer`
+     - MySQL — `HARMONICA_TEST_MYSQL_HOST`/`_PORT`/`_DB`/`_USER`/`_PASSWORD`
+       → `127.0.0.1`/`3306`/`harmonica_test`/`developer`/`developer`
+   - Gating (optional profile, default/local): short-timeout connectivity
+     probe in `@BeforeAll` (≤2 s connect timeout) → `Assumptions.abort`; a
+     down/absent DB **skips** the suite, so `./gradlew build` stays green
+     without Docker.
+   - Wiring: SQLite runs in `./gradlew build` (always-green fast path, `test`
+     source set); PostgreSQL/MySQL run via `:integration-test:integrationTest`
+     (separate `integrationTest` source set) — never in `build`.
 2. **Port `harmonica_test`** — the 4 migrations (normal/not-null/default/other)
    and Postgres/MySql/Sqlite configs move in as JVM-level JDBC assertions
    (table/columns/index/data) after `Connection.transaction { up() }` / `down()`.
    SQLite is always-green (embedded); PostgreSQL/MySQL run when available.
 3. **H2 embedded path** — add `Dbms.H2` connection-URI support to `core`
    (currently returns `""`; `SqlServerAdapter` stays TODO, Phase 5) + H2 test
-   driver. Second Docker-free DBMS alongside SQLite.
+   driver. Second Docker-free DBMS alongside SQLite. URI and lifecycle contract:
+   - In-process tests: `jdbc:h2:mem:<dbName>;DB_CLOSE_DELAY=-1`, with a unique
+     `<dbName>` per test (or explicit schema cleanup) so tests do not collide.
+   - TestKit tests (item 4): file-backed URL with a unique absolute path;
+     delete the H2 DB files after all TestKit processes have closed.
+   - The H2 driver is test/integration runtime-only — never published from
+     `core`.
+   - The expected H2 URI will be asserted in `ConnectionTest`; `testing.md`
+     keeps the same contract.
 4. **Plugin-flow tests (issue #196)** — Gradle TestKit runs the `harmonica`
    up/down tasks against a real DB **with and without** `harmonica-exposed` on
    the script classpath. Seeds from the local `demo/` scratch project (rewritten
    for the direct scripting host), which gets committed here.
 5. **Docker + CI** — `docker-compose.yml` at the repo root (postgres:16,
    mysql:8, `developer`/`developer`, DB `harmonica_test`); a `db-integration`
-   CI job runs the gated suite against Postgres/MySQL service containers (see
-   [`ci.md`](ci.md) §3.1); SQLite/H2 stay in the fast path.
+   CI job runs the gated suite against Postgres/MySQL service containers in
+   **required** mode: `HARMONICA_TEST_DB_REQUIRED` set only in CI makes the
+   probe bounded-retry and **fails** on invalid config, missing credentials,
+   unavailable service, or any skipped DB test — never skips (see
+   [`ci.md`](ci.md) §3.1); SQLite (and later H2) stay in the fast path.
 
 Test framework/tooling decision: **JUnit 6.x** (in `core`/`gradle-plugin` since
 Phase 2, PR #186). Testcontainers optional later; env-var config + compose
@@ -264,9 +286,11 @@ services are the baseline so the suite runs without container APIs.
 Definition of done:
 
 - `integration-test` module exists in this repo, ported from `harmonica_test`.
-- `./gradlew build` passes without Docker; `integrationTest` passes with it.
-- SQLite + H2 real-DB tests are part of the always-on fast path.
-- Postgres + MySQL suites green locally (Docker) and in CI (service containers).
+- `./gradlew build` runs the SQLite (and later H2) embedded tests via the
+  module's `test` task and passes without Docker; the gated PostgreSQL/MySQL
+  suite runs via the `integrationTest` task and passes with Docker.
+- Postgres + MySQL suites green locally (Docker) and in CI (the `db-integration`
+  service-container job, required mode).
 - Issue #196 satisfied — the migration flow is verified with and without
   `harmonica-exposed` on the classpath.
 

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -22,10 +22,9 @@
   commit path (DDL + insert persist) and the rollback path (exception inside
   `exposedTransaction` rolls back and reconnects). This is the first real-DB
   test in the repo, and it is green without Docker.
-- Real-DB tests (`harmonica_test`) require a live PostgreSQL/MySQL with a
-  `developer/developer` user and a `harmonica_test` database; they are a
-  separate Gradle project and only run manually.
-- This machine: no Docker, no local DBMS yet (SQLite embedded tests run fine).
+- Real-DB tests read env vars with local defaults and run in a gated suite
+  (Phase 4, §3) — SQLite embedded tests run fine; PostgreSQL/MySQL skip when
+  their services are absent.
 
 ## Plan
 
@@ -63,25 +62,38 @@ services:
 - SQLite needs no server. It **is** covered by the embedded tests in the
   `exposed` module today (Phase 3, PR B); keep an always-green SQLite path in
   CI (`org.xerial:sqlite-jdbc` + a temp-file/`:memory:` DB) and extend the
-  pattern to a **Docker-free SQLite integration path** for `core` gated by the
-  same env-var helper.
+  pattern to an always-green **Docker-free SQLite integration path** for `core`
+  running in `build`'s `test` task, reusing the same env-var/config helper.
 - **H2 as the Docker-free alternative**: `Connection.buildConnectionUriFromDbConfig`
   returns `""` for `Dbms.H2` and `SqlServerAdapter` is 100% TODO. Add H2
   support as an embedded (no-server) DBMS alongside SQLite; defer SQL Server /
-  Oracle to a later phase (they still require services).
+  Oracle to a later phase (they still require services). URI and lifecycle
+  contract (mirrored in `spec/plan.md` Phase 4): in-process tests use
+  `jdbc:h2:mem:<dbName>;DB_CLOSE_DELAY=-1` with a unique `<dbName>` per test (or
+  explicit schema cleanup); TestKit tests use a file-backed URL at a unique
+  absolute path and delete the H2 DB files after all TestKit processes close;
+  the H2 driver is test/integration runtime-only, never published from `core`.
 - Document start/stop and how to run the integration suite against them.
 
 ### 3. Gating (DB may be absent)
 
-- Integration tests read connection info from env vars
-  (`HARMONICA_TEST_DB_URL` etc.) or known local defaults.
-- JUnit (6.x): use `@EnabledIfEnvironmentVariable` / an assumption helper so tests
-  **skip** (not fail) when the DB is unreachable.
-- Add a short-timeout **connectivity probe** (e.g. open the JDBC connection
-  with a 1–2 s connect timeout in a `@BeforeAll`; on failure, `Assumptions.abort`)
-  so a down/absent DB **skips** the suite instead of failing it.
-- The default `./gradlew build` includes unit tests only; DB tests run via a
-  separate task (e.g. `integrationTest`) or a `-PwithDb` flag.
+- Integration tests read connection info from env vars with known local
+  defaults; precedence is env-var > default:
+  - PostgreSQL — `HARMONICA_TEST_POSTGRES_HOST`/`_PORT`/`_DB`/`_USER`/`_PASSWORD`
+    → `127.0.0.1`/`5432`/`harmonica_test`/`developer`/`developer`.
+  - MySQL — `HARMONICA_TEST_MYSQL_HOST`/`_PORT`/`_DB`/`_USER`/`_PASSWORD`
+    → `127.0.0.1`/`3306`/`harmonica_test`/`developer`/`developer`.
+- Gating (default/local — optional profile): a short-timeout **connectivity
+  probe** (e.g. open the JDBC connection with a 1–2 s connect timeout in a
+  `@BeforeAll`; on failure, `Assumptions.abort`) so a down/absent DB **skips**
+  the suite instead of failing it.
+- The CI `db-integration` job (Phase 4, item 5) runs in **required** mode:
+  `HARMONICA_TEST_DB_REQUIRED` set only in CI turns the probe into a
+  bounded-retry check that **fails** on invalid configuration, missing
+  credentials, unavailable services, or skipped DB tests — never skips.
+- The always-green SQLite (and later H2) embedded tests run in `./gradlew build`
+  via the `integration-test` module's `test` task; the gated PostgreSQL/MySQL
+  suite runs via the `integrationTest` task — never in `build`.
 
 ### 4. CI
 
@@ -89,7 +101,7 @@ services:
   containers (Postgres/MySQL) so every merge is verified against real DBs.
 - Keep a plain unit-test job as the fast path and as the JDK 8-bytecode check
   (javap major-version assertion — see [`ci.md`](ci.md)).
-- SQLite/H2 tests run in the fast path (no services needed).
+- SQLite (and later H2) tests run in the fast path (no services needed).
 - Remove/replace the legacy CircleCI config once Actions is authoritative. —
   **done** (Phase 0).
 
@@ -104,6 +116,8 @@ services:
 
 - `integration-test` module exists in this repo, ported from `harmonica_test`.
 - `docker-compose.yml` + docs committed; local run verified on this machine.
-- `./gradlew build` passes without Docker; `integrationTest` passes with Docker.
-- SQLite + H2 real-DB smoke tests are part of the always-on fast path.
-- CI job runs DB-backed tests on every push.
+- `./gradlew build` runs the SQLite (and later H2) embedded tests via the
+  module's `test` task and passes without Docker; `integrationTest` passes with
+  Docker.
+- SQLite (and later H2) real-DB smoke tests are part of the always-on fast path.
+- CI `db-integration` job runs DB-backed tests on every push (required mode).


### PR DESCRIPTION
Fleshes out the Phase 4 placeholder in spec/plan.md into 5 small PR-sized work items (integration module scaffold, harmonica_test port, H2 embedded path, plugin-flow tests for issue #196, Docker + CI) with a definition of done. Docker is now installed on the dev machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded the database integration testing plan to cover SQLite, H2, PostgreSQL, and MySQL.
  - Added coverage for migration flows and optional Exposed integration.
  - Defined separate handling for unavailable database environments, allowing those tests to be skipped safely.
  - Added plans for Docker Compose-based services and automated CI verification.
- **Documentation**
  - Clarified the testing phases, execution requirements, and definition of done for database compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->