### PR TITLE
Add integration-test module (Phase 4 test infra)

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -1,0 +1,84 @@
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    create("integrationTest")
+}
+
+dependencies {
+    implementation(project(":core"))
+    implementation(project(":exposed"))
+
+    testImplementation("org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.2")
+    testImplementation("org.xerial:sqlite-jdbc:3.45.3.0")
+
+    add("integrationTestImplementation", project(":core"))
+    add("integrationTestImplementation", project(":exposed"))
+    add("integrationTestImplementation", "org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
+    add("integrationTestImplementation", "org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")
+    add("integrationTestImplementation", "org.junit.jupiter:junit-jupiter:6.1.2")
+    add("integrationTestRuntimeOnly", "org.junit.platform:junit-platform-launcher:6.1.2")
+    add("integrationTestImplementation", "org.postgresql:postgresql:42.7.4")
+    add("integrationTestImplementation", "com.mysql:mysql-connector-j:8.4.0")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+}
+
+tasks.test {
+    // Always-green embedded tests (SQLite) run in every `build`.
+    useJUnitPlatform()
+}
+
+val integrationTest = tasks.register<Test>("integrationTest") {
+    group = "verification"
+    description = "Runs the real-DB integration suite; skips when a database is unreachable"
+    useJUnitPlatform()
+    testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+    classpath = sourceSets["integrationTest"].runtimeClasspath
+}
+
+// JUnit 6 requires Java 17+, but published bytecode must stay JVM 8
+// (jvmTarget = JVM_1_8 above). Override the attribute on the test classpaths
+// only; tests run on the installed JDK (25), which satisfies the 17+ baseline.
+configurations {
+    testCompileClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+    named("integrationTestCompileClasspath") {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+    named("integrationTestRuntimeClasspath") {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+}

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/PostgreSqlMigrationTest.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/PostgreSqlMigrationTest.kt
@@ -1,0 +1,60 @@
+package com.improve_future.harmonica.integration
+
+import com.improve_future.harmonica.core.AbstractMigration
+import com.improve_future.harmonica.core.Connection
+import com.improve_future.harmonica.core.Dbms
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PostgreSqlMigrationTest {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun requirePostgres() {
+            val url = "jdbc:postgresql://${TestDb.postgresHost}:${TestDb.postgresPort}/${TestDb.postgresDb}"
+            TestDb.requireDb(url, TestDb.postgresUser, TestDb.postgresPassword)
+        }
+    }
+
+    @Test
+    fun createTableAndDropTable() {
+        Connection.create {
+            dbms = Dbms.PostgreSQL
+            host = TestDb.postgresHost
+            port = TestDb.postgresPort
+            dbName = TestDb.postgresDb
+            user = TestDb.postgresUser
+            password = TestDb.postgresPassword
+        }.use { connection ->
+            connection.transaction {
+                object : AbstractMigration() {
+                    override fun up() {
+                        createTable("postgres_table") {
+                            varchar("name")
+                        }
+                    }
+
+                    override fun down() {}
+                }.apply {
+                    this.connection = connection
+                }.up()
+            }
+            assertTrue(connection.doesTableExist("postgres_table"))
+
+            connection.transaction {
+                object : AbstractMigration() {
+                    override fun up() {}
+
+                    override fun down() {
+                        dropTable("postgres_table")
+                    }
+                }.apply {
+                    this.connection = connection
+                }.down()
+            }
+            assertFalse(connection.doesTableExist("postgres_table"))
+        }
+    }
+}

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/PostgreSqlMigrationTest.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/PostgreSqlMigrationTest.kt
@@ -5,6 +5,7 @@ import com.improve_future.harmonica.core.Connection
 import com.improve_future.harmonica.core.Dbms
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -20,41 +21,42 @@ class PostgreSqlMigrationTest {
 
     @Test
     fun createTableAndDropTable() {
-        Connection.create {
+        val tableName = "postgres_table_${UUID.randomUUID().toString().replace("-", "")}"
+        val connection = Connection.create {
             dbms = Dbms.PostgreSQL
             host = TestDb.postgresHost
             port = TestDb.postgresPort
             dbName = TestDb.postgresDb
             user = TestDb.postgresUser
             password = TestDb.postgresPassword
-        }.use { connection ->
+        }
+        try {
             connection.transaction {
                 object : AbstractMigration() {
                     override fun up() {
-                        createTable("postgres_table") {
+                        createTable(tableName) {
                             varchar("name")
                         }
                     }
-
-                    override fun down() {}
                 }.apply {
                     this.connection = connection
                 }.up()
             }
-            assertTrue(connection.doesTableExist("postgres_table"))
-
-            connection.transaction {
-                object : AbstractMigration() {
-                    override fun up() {}
-
-                    override fun down() {
-                        dropTable("postgres_table")
-                    }
-                }.apply {
-                    this.connection = connection
-                }.down()
+            assertTrue(connection.doesTableExist(tableName))
+        } finally {
+            if (connection.doesTableExist(tableName)) {
+                connection.transaction {
+                    object : AbstractMigration() {
+                        override fun down() {
+                            dropTable(tableName)
+                        }
+                    }.apply {
+                        this.connection = connection
+                    }.down()
+                }
             }
-            assertFalse(connection.doesTableExist("postgres_table"))
+            connection.close()
         }
+        assertFalse(connection.doesTableExist(tableName))
     }
 }

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/TestDb.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/TestDb.kt
@@ -1,0 +1,31 @@
+package com.improve_future.harmonica.integration
+
+import org.junit.jupiter.api.Assumptions
+import java.sql.DriverManager
+import java.sql.SQLException
+
+object TestDb {
+    val postgresHost = env("HARMONICA_TEST_POSTGRES_HOST", "127.0.0.1")
+    val postgresPort = env("HARMONICA_TEST_POSTGRES_PORT", "5432").toInt()
+    val postgresDb = env("HARMONICA_TEST_POSTGRES_DB", "harmonica_test")
+    val postgresUser = env("HARMONICA_TEST_POSTGRES_USER", "developer")
+    val postgresPassword = env("HARMONICA_TEST_POSTGRES_PASSWORD", "developer")
+
+    val mysqlHost = env("HARMONICA_TEST_MYSQL_HOST", "127.0.0.1")
+    val mysqlPort = env("HARMONICA_TEST_MYSQL_PORT", "3306").toInt()
+    val mysqlDb = env("HARMONICA_TEST_MYSQL_DB", "harmonica_test")
+    val mysqlUser = env("HARMONICA_TEST_MYSQL_USER", "developer")
+    val mysqlPassword = env("HARMONICA_TEST_MYSQL_PASSWORD", "developer")
+
+    private fun env(name: String, default: String): String =
+        System.getenv(name) ?: default
+
+    fun requireDb(url: String, user: String, password: String) {
+        try {
+            DriverManager.setLoginTimeout(2)
+            DriverManager.getConnection(url, user, password).close()
+        } catch (e: SQLException) {
+            Assumptions.abort("Database unavailable at $url: ${e.message}")
+        }
+    }
+}

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/TestDb.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/TestDb.kt
@@ -21,11 +21,14 @@ object TestDb {
         System.getenv(name) ?: default
 
     fun requireDb(url: String, user: String, password: String) {
+        val previousTimeout = DriverManager.getLoginTimeout()
         try {
             DriverManager.setLoginTimeout(2)
             DriverManager.getConnection(url, user, password).close()
         } catch (e: SQLException) {
             Assumptions.abort("Database unavailable at $url: ${e.message}")
+        } finally {
+            DriverManager.setLoginTimeout(previousTimeout)
         }
     }
 }

--- a/integration-test/src/test/kotlin/com/improve_future/harmonica/integration/SqliteMigrationTest.kt
+++ b/integration-test/src/test/kotlin/com/improve_future/harmonica/integration/SqliteMigrationTest.kt
@@ -1,0 +1,55 @@
+package com.improve_future.harmonica.integration
+
+import com.improve_future.harmonica.core.AbstractMigration
+import com.improve_future.harmonica.core.Connection
+import com.improve_future.harmonica.core.Dbms
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SqliteMigrationTest {
+    @Test
+    fun createTableAndDropTable() {
+        val dbPath = Path.of("build", "test-db", "sqlite_integration")
+        Files.createDirectories(dbPath.parent)
+        for (suffix in listOf(".db", ".db-wal", ".db-shm")) {
+            Files.deleteIfExists(Path.of(dbPath.toString() + suffix))
+        }
+        Connection.create {
+            dbms = Dbms.SQLite
+            dbName = dbPath.toString()
+            user = ""
+            password = ""
+        }.use { connection ->
+            connection.transaction {
+                object : AbstractMigration() {
+                    override fun up() {
+                        createTable("migration_table") {
+                            varchar("name")
+                        }
+                    }
+
+                    override fun down() {}
+                }.apply {
+                    this.connection = connection
+                }.up()
+            }
+            assertTrue(connection.doesTableExist("migration_table"))
+
+            connection.transaction {
+                object : AbstractMigration() {
+                    override fun up() {}
+
+                    override fun down() {
+                        dropTable("migration_table")
+                    }
+                }.apply {
+                    this.connection = connection
+                }.down()
+            }
+            assertFalse(connection.doesTableExist("migration_table"))
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,4 +6,4 @@ pluginManagement {
 }
 
 rootProject.name = "harmonica"
-include("core", "exposed", "gradle-plugin")
+include("core", "exposed", "gradle-plugin", "integration-test")


### PR DESCRIPTION
Part of Phase 4 (spec/testing.md). Adds a new `integration-test` module with:

- **`test` source set** — embedded, always-green suite (SQLite) that runs in every `./gradlew build`.
- **`integrationTest` source set** — real-DB suite (PostgreSQL now; MySQL/H2 later) that runs only via `:integration-test:integrationTest`, gated by a 2s-login-timeout connectivity probe (`TestDb.requireDb`) that **aborts via JUnit assumption** when the DB is unreachable, so CI stays green without Docker.

Design matches spec/testing.md §3 and §4:
- SQLite smoke test runs in `build` (fast path); DB tests run via the separate `integrationTest` task.
- DB host/port/creds come from `HARMONICA_TEST_*` env vars with defaults matching the testing.md §2 docker-compose spec (`developer`/`developer`, `harmonica_test`).
- jvmTarget 1.8 preserved (JVM 8 bytecode), `TargetJvmVersion=17` override on test classpaths for JUnit 6.
- No unused deps, no Exposed in core.

Follow-ups (later PRs, not here): MySQL/H2 tests (H2 waits for #206), docker-compose.yml + docs (testing.md DoD), db-integration CI job with service containers (ci.md §3.1), plan-review doc updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated migration coverage for SQLite and PostgreSQL.
  * Verified table creation and removal through migration workflows.
  * Added database availability checks for integration test execution.
* **Chores**
  * Added a dedicated integration-test project with JUnit Platform support.
  * Configured JVM 8 compilation and real-database test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->