### PR TITLE
update spec docs

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -33,8 +33,8 @@ plan to restart and modernize the project.
   `actions/setup-java@v5.7.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (dependency-graph submission). CircleCI removed.
 - Four active modules: `core`, `exposed`, `gradle-plugin`, `integration-test` —
-  **85 tests green** (73 core + 6 plugin + 4 exposed + 2 integration-test, of
-  which the gated PostgreSQL test skips without a DB); `document` (nested
+  **85 tests total: 84 passed, 1 skipped (gated PostgreSQL), 0 failures**
+  (73 core + 6 plugin + 4 exposed + 2 integration-test); `document` (nested
   standalone build) is excluded from the build
 - H2 embedded DBMS support in `core` (PR #206): `Dbms.H2` → `jdbc:h2:<dbName>`,
   `H2Adapter` complete, H2 2.2.224 test-only; in-memory DB state survives a

--- a/spec/README.md
+++ b/spec/README.md
@@ -16,9 +16,10 @@ plan to restart and modernize the project.
 
 ## Current state (baseline, branch `develop`)
 
-> Snapshot taken 2026-08-11, after Phase 3 (Exposed bridge, PRs #197-#199;
-> script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203).
-> Update this list when the baseline advances.
+> Snapshot taken 2026-08-15, after Phase 3 (Exposed bridge, PRs #197-#199;
+> script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203) and the
+> start of Phase 4 (H2 embedded DBMS, PR #206; integration-test module, PR
+> #207). Update this list when the baseline advances.
 
 - Kotlin **2.3.20**, Gradle wrapper **9.6.1**, `jvmTarget = 1.8` (class-file
   major 52 asserted in CI)
@@ -29,11 +30,20 @@ plan to restart and modernize the project.
   prep
 - CI: GitHub Actions only — `ci.yml` (PR/push, Temurin JDK 25,
   `actions/checkout@v7` + `gradle/actions/setup-gradle@v6` +
-  `actions/setup-java@5.7.0`), `jvm8-bytecode.yml` (major-52 assertion),
-  `dependency-submit.yml` (Dependabot). CircleCI removed.
-- Three active modules: `core`, `exposed`, `gradle-plugin` — **78 tests green**
-  (68 core + 6 plugin + 4 exposed); `document` (nested standalone build) is
-  excluded from the build
+  `actions/setup-java@v5.7.0`), `jvm8-bytecode.yml` (major-52 assertion),
+  `dependency-submit.yml` (dependency-graph submission). CircleCI removed.
+- Four active modules: `core`, `exposed`, `gradle-plugin`, `integration-test` —
+  **85 tests green** (73 core + 6 plugin + 4 exposed + 2 integration-test, of
+  which the gated PostgreSQL test skips without a DB); `document` (nested
+  standalone build) is excluded from the build
+- H2 embedded DBMS support in `core` (PR #206): `Dbms.H2` → `jdbc:h2:<dbName>`,
+  `H2Adapter` complete, H2 2.2.224 test-only; in-memory DB state survives a
+  failed `transaction` (connection kept open for H2), identifier case derived
+  from `DatabaseMetaData`
+- The `integration-test` module (PR #207) replaces the separate `harmonica_test`
+  repository: SQLite embedded suite runs in `./gradlew build`; the PostgreSQL
+  suite runs via `:integration-test:integrationTest` and skips when the DB is
+  unreachable (MySQL + full `harmonica_test` port + Docker/CI still Phase 4)
 - Migration `.kts` scripts are compiled/evaluated with a direct
   `BasicJvmScriptingHost` from a `MigrationScript` `@KotlinScript` template
   (PR #202) — no JSR-223 engine — over the plugin's `harmonica` configuration
@@ -45,14 +55,17 @@ plan to restart and modernize the project.
   (Phase 3, PR B); runtime reflection detection was removed from
   `gradle-plugin` (PR A) — see
   [`exposed-integration.md`](exposed-integration.md)
-- Tests for real DBMS still live in the separate `harmonica_test` repository —
-  to be merged in Phase 4
-- **`develop` is 83 commits ahead of `master`** — Phase 4 (real-DB tests) must
+- Tests for real DBMS are being merged in Phase 4: the `integration-test`
+  module is in the root build (SQLite always-green, PostgreSQL gated); the
+  full `harmonica_test` port, MySQL, Docker/CI wiring, and the issue #196
+  with/without-Exposed flow remain
+- **`develop` is 96 commits ahead of `master`** — Phase 4 (real-DB tests) must
   pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 
 ## Machine environment (current)
 
 - OpenJDK 25.0.3 (only JDK installed)
-- No standalone `gradle`, no `docker`
+- No standalone `gradle`; **Docker installed 2026-08-15** (user added to the
+  `docker` group) for the Phase 4 DB-backed tests
 - Toolchain upgrade done (Phase 0, PR #183): the Gradle 9.6.1 wrapper runs on
   Java 25, so `./gradlew build` works locally.

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-11 (**28 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-15 (**28 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 
@@ -26,14 +26,13 @@ superseded by Phase 0.
 | # | Title | Plan |
 | --- | --- | --- |
 | 189 | `isSubtypeOf` in scanner swallows all `Throwable` | Narrow to recoverable exceptions to match `loadClass` (PR #188); small fix in `JarmonicaTaskMain`. |
-| 196 | Real-DB tests must cover both configs: with and without Exposed | Phase 3/4 verification: run the migration flow against a real DB with and without `harmonica-exposed` on the classpath (SQLite embedded now, PostgreSQL/MySQL in Phase 4). |
+| 196 | Real-DB tests must cover both configs: with and without Exposed | Phase 4 item 4 (plugin-flow TestKit tests). The `integration-test` module landed (PR #207) with SQLite + gated PostgreSQL smoke tests, but the with/without-`harmonica-exposed` migration-flow verification is still pending. |
 | 182 | README JitPack badge shows nothing | Fix JitPack badge so it renders (README badge URLs fixed in PR #181, but this badge still broken). |
 | 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
 | 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |
 | 138 | Is there a need to make AbstractColumn internal? | Open up custom-column extension points (make `AbstractColumn`/`ColumnBuilder` public, document custom column pattern). |
 | 141 | Add support to more column types | Long is done; add Enumeration and other missing types (see Exposed type list). |
 | 145 | Add alter column function | Add `alterColumn` to change type/options. |
-| 67 | Default value for timestamp | Medium-ish small: default `DEFAULT CURRENT_TIMESTAMP` (or constant) for `createTimestamp` etc.; ties into #85 SQLite-defaults research. |
 | 139 | Update addForeignKey | Support ON DELETE / ON UPDATE / constraint options. |
 | 69 | Add sophisticated query executing method | Provide a richer `executeQuery`/query-returning API. |
 | 4 | add timestamp syntax to add created_at and updated_at | Convenience columns/timestamps helper. |
@@ -44,6 +43,7 @@ superseded by Phase 0.
 | --- | --- | --- |
 | 7 | Sometimes migration stops because of closed connection | Reproduce & fix connection lifecycle (README "Caution" section documents a workaround). |
 | 85 | Research SQLite default value in other migration tools | Research rails/phinx behavior; align `createTime`/`createDateTime`/`createTimestamp` defaults for SQLite. |
+| 67 | Default value for timestamp | `DEFAULT CURRENT_TIMESTAMP` (or constant) for `createTimestamp` etc.; ties into #85 SQLite-defaults research. |
 | 80 | Update exposed version | Out of harmonica's control once Exposed is optional (see exposed-integration.md); document supported version. |
 | 71 | consider to add or not seeding function | Decide scope; if yes, design a `seed` task. |
 | 97 | Add Test to Sub Classes of JavaExec | Gradle TestKit tests for `JarmonicaMigrationTask` and friends. |

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -35,10 +35,10 @@ State:
 
 - `master` (origin/master @ `3b423c6`) has not been touched in years and is the
   direct ancestor of `develop` (merge-base == master HEAD).
-- `develop` is **83 commits ahead** (module split into `core`/`gradle-plugin`,
+- `develop` is **96 commits ahead** (module split into `core`/`gradle-plugin`,
   jcenter removal work, MIT license change, CI-action bumps, Phase 3 Exposed
-  bridge, etc.) but **never fully tested or released** — this is why master was
-  left behind.
+  bridge, Phase 4 start, etc.) but **never fully tested or released** — this is
+  why master was left behind.
 
 Policy going forward (Git Flow, simplified):
 
@@ -79,7 +79,7 @@ Consequences for the restart:
   fast-forward `master` until Phase 0 is green and DB tests (Phase 4) pass.
 - **Status (post-Phase 0/2):** the split build is verified — `core` and
   `gradle-plugin` build, test (72 tests green; snapshot before the Phase 3
-  `exposed` module — see spec/README for the current 78), and package correctly on
+  `exposed` module — see spec/README for the current 85), and package correctly on
   Java 25 and in CI; `document/` is excluded from the build. Phase 0 also proved
   the POM/publication config (PR #183) and the Groovy→Kotlin DSL migration. The
   remaining unverified risk is real-DB behavior, which Phase 4 covers.
@@ -172,7 +172,7 @@ Outcome: no dead repositories or unmaintained libraries in the build.
 Status: **merged 2026-08-01 (PRs #184-#188).** All build files now use only
 Maven Central (`document/` excluded from build). 72 tests green (68 core + 4
 gradle-plugin; Phase 0 baseline was 66; `ScriptClasspathTest` later added 2
-plugin tests (PR #201) — see spec/README for the current 78).
+plugin tests (PR #201) — see spec/README for the current 85).
 
 - `gradle.properties`: `kotlin_version` → 2.3.x. — **done in Phase 0** (2.3.20).
 - Dead repositories: **gone** — jcenter/bintray/space removed; jitpack removed
@@ -220,7 +220,8 @@ ownership via a no-op commit/rollback/close proxy; `WeakHashMap`-cached
 `Database` per `Connection`; `defaultMaxAttempts = 1`) with 4 SQLite tests:
 commit, rollback, reconnect, and SQLException propagation through the proxy
 (exceptions unwrapped from `InvocationTargetException` so they keep their
-`SQLException` type). **78 tests green** (68 core + 6 plugin + 4 exposed).
+`SQLException` type). **78 tests green** (68 core + 6 plugin + 4 exposed) by the
+end of Phase 3 — see spec/README for the current 85.
 Script-classpath wiring for `.kts` migrations (Pitfall F) shipped **2026-08-11
 (PRs #201, #202)**: the plugin evaluates `.kts` scripts directly with
 `BasicJvmScriptingHost` from a `MigrationScript` `@KotlinScript` template (no
@@ -243,12 +244,17 @@ Plan:
 
 Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
 
-**Status: in progress (2026-08-11).** Docker/Compose is a reproducible dev+CI
-dependency (item 5, [`ci.md`](ci.md) §3.1), not a machine-local detail.
-Breakdown (each item is its own small PR against `develop`):
+**Status: in progress (2026-08-15).** Items 1 (integration-test module, PR
+#207) and 3 (H2 embedded path, PR #206) have landed; item 2 is partially landed
+(SQLite always-green smoke test + gated PostgreSQL smoke test in PR #207; the
+full `harmonica_test` port is still pending). Items 4-5 remain. Docker/Compose
+is a reproducible dev+CI dependency (item 5, [`ci.md`](ci.md) §3.1), not a
+machine-local detail. Breakdown (each item is its own small PR against
+`develop`):
 
 1. **Integration module scaffold** (`integration-test` subproject, per
-   [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`.
+   [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`. **DONE
+   (2026-08-15, PR #207).**
    - Connection info from env vars with known local defaults; precedence is
      env-var > default:
      - PostgreSQL — `HARMONICA_TEST_POSTGRES_HOST`/`_PORT`/`_DB`/`_USER`/
@@ -266,8 +272,11 @@ Breakdown (each item is its own small PR against `develop`):
    and Postgres/MySql/Sqlite configs move in as JVM-level JDBC assertions
    (table/columns/index/data) after `Connection.transaction { up() }` / `down()`.
    SQLite is always-green (embedded); PostgreSQL/MySQL run when available.
+   **Partial (PR #207):** SQLite embedded test runs in `./gradlew build`; a
+   gated PostgreSQL create/drop smoke test runs via `integrationTest`. The full
+   4-migration port (columns/indexes/data assertions, MySQL config) is pending.
 3. **H2 embedded path** — add `Dbms.H2` connection-URI support to `core`
-   (currently returns `""`; `SqlServerAdapter` stays TODO, Phase 5) + H2 test
+   (previously returned `""`; `SqlServerAdapter` stays TODO, Phase 5) + H2 test
    driver. Second Docker-free DBMS alongside SQLite. URI and lifecycle contract:
    - In-process tests: `jdbc:h2:mem:<dbName>;DB_CLOSE_DELAY=-1`, with a unique
      `<dbName>` per test (or explicit schema cleanup) so tests do not collide.
@@ -275,8 +284,15 @@ Breakdown (each item is its own small PR against `develop`):
      delete the H2 DB files after all TestKit processes have closed.
    - The H2 driver is test/integration runtime-only — never published from
      `core`.
-   - The expected H2 URI will be asserted in `ConnectionTest`; `testing.md`
+   - The expected H2 URI is asserted in `ConnectionTest`; `testing.md`
      keeps the same contract.
+   **DONE (2026-08-15, PR #206).** `Dbms.H2` builds `jdbc:h2:<dbName>`;
+   `H2Adapter` is complete; H2 2.2.224 is `testImplementation`-only. In-memory
+   state across rollback/reconnect is preserved by keeping the connection open
+   after a failed `transaction` for H2 (no `DB_CLOSE_DELAY` needed); identifier
+   case is normalized from `DatabaseMetaData` (`DATABASE_TO_LOWER` supported).
+   The `DB_CLOSE_DELAY=-1` bullet above is **superseded** by this
+   connection-keeping choice; `testing.md` was updated to match (2026-08-15).
 4. **Plugin-flow tests (issue #196)** — Gradle TestKit runs the `harmonica`
    up/down tasks against a real DB **with and without** `harmonica-exposed` on
    the script classpath. Seeds from the local `demo/` scratch project (rewritten
@@ -287,7 +303,7 @@ Breakdown (each item is its own small PR against `develop`):
    **required** mode: `HARMONICA_TEST_DB_REQUIRED` set only in CI makes the
    probe bounded-retry and **fails** on invalid config, missing credentials,
    unavailable service, or any skipped DB test — never skips (see
-   [`ci.md`](ci.md) §3.1); SQLite (and later H2) stay in the fast path.
+    [`ci.md`](ci.md) §3.1); SQLite and H2 stay in the fast path.
 
 Test framework/tooling decision: **JUnit 6.x** (in `core`/`gradle-plugin` since
 Phase 2, PR #186). Testcontainers optional later; env-var config + compose
@@ -296,9 +312,10 @@ services are the baseline so the suite runs without container APIs.
 Definition of done:
 
 - `integration-test` module exists in this repo, ported from `harmonica_test`.
-- `./gradlew build` runs the SQLite (and later H2) embedded tests via the
-  module's `test` task and passes without Docker; the gated PostgreSQL/MySQL
-  suite runs via the `integrationTest` task and passes with Docker.
+- `./gradlew build` runs the SQLite (integration-test `test` task) and H2
+  (`core` `test` task) embedded tests and passes without Docker; the gated
+  PostgreSQL/MySQL suite runs via the `integrationTest` task and passes with
+  Docker.
 - Postgres + MySQL suites green locally (Docker) and in CI (the `db-integration`
   service-container job, required mode).
 - Issue #196 satisfied — the migration flow is verified with and without
@@ -313,7 +330,8 @@ Full triage: [issues-triage.md]. Order:
    pluralizer PR #187); #158, #159 already closed (verified; not tracked here).
 2. Small: #26 (migration file naming), #47 (prepared statements), #138 (custom
    columns), #141 (more column types), #145 (alter column), #139 (FK options),
-   #69 (query execution API), #4 (created_at/updated_at), #182 (JitPack badge).
+   #69 (query execution API), #4 (created_at/updated_at), #182 (JitPack badge),
+   #189 (scanner `isSubtypeOf` swallows all `Throwable`).
    #91 (Exposed) is **closed** — the bridge shipped in Phase 3 (PRs #197-#199).
 3. Medium: #7 (closed connection), #85 (SQLite defaults), #67 (timestamp
    default), #80 (Exposed version), #71 (seeding), #97 (JavaExec task tests),
@@ -380,7 +398,8 @@ Resolved (2026-08-01):
   catches only `ClassNotFoundException` + `LinkageError`. `isSubtypeOf` still
   catches `Throwable` — issue #189 (Phase 2, PRs #185/#188).
 - Kotlin `jvm` plugin bump 2.3.20 → 2.4.10 (PR #193): **declined** — no
-  functional need; stay on 2.3.20, revisit before the next phase.
+  functional need; stay on 2.3.20. PR #193 is still open (dependabot) as of
+  2026-08-15; revisit before the next phase.
 
 Still open:
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -244,8 +244,8 @@ Plan:
 
 Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
 
-**Status: in progress (2026-08-15).** Items 1 (integration-test module, PR
-#207) and 3 (H2 embedded path, PR #206) have landed; item 2 is partially landed
+**Status: in progress (2026-08-15).** Items 1 (integration-test module, PR `#207`)
+and 3 (H2 embedded path, PR `#206`) have landed; item 2 is partially landed
 (SQLite always-green smoke test + gated PostgreSQL smoke test in PR #207; the
 full `harmonica_test` port is still pending). Items 4-5 remain. Docker/Compose
 is a reproducible dev+CI dependency (item 5, [`ci.md`](ci.md) §3.1), not a

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -6,10 +6,9 @@ file as versions change.
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **85 tests pass, 0 failures**
-  (73 core, 6 gradle-plugin, 4 exposed, 2 integration-test of which 1 is the
-  gated PostgreSQL suite that **skips** without a DB — Docker-less runs are
-  84/84). Phase 0 baseline was 66; Phase 2 added 6 InflectionsTest cases;
+  `./gradlew clean build` is green on Java 25; **85 tests total: 84 passed,
+  1 skipped (gated PostgreSQL), 0 failures** (73 core, 6 gradle-plugin,
+  4 exposed, 2 integration-test — Docker-less runs are 84/84). Phase 0 baseline was 66; Phase 2 added 6 InflectionsTest cases;
   Phase 3, PR B added 4 ExposedMigrationTest cases; PR #201 added 2
   ScriptClasspathTest cases; Phase 4 added 5 H2 cases in `core` (PR #206) and
   the 2 integration-test cases (PR #207).

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,21 +1,25 @@
 # Toolchain & Dependency Research
 
-Facts gathered on 2026-08-01 (test counts updated 2026-08-11). Update this
+Facts gathered on 2026-08-01 (test counts updated 2026-08-15). Update this
 file as versions change.
 
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **78 unit tests pass (68 core,
-  6 gradle-plugin, 4 exposed), 0 failures/errors** (Phase 0 baseline was 66;
-  Phase 2 added 6 InflectionsTest cases; Phase 3, PR B added 4
-  ExposedMigrationTest cases; PR #201 added 2 ScriptClasspathTest cases).
+  `./gradlew clean build` is green on Java 25; **85 tests pass, 0 failures**
+  (73 core, 6 gradle-plugin, 4 exposed, 2 integration-test of which 1 is the
+  gated PostgreSQL suite that **skips** without a DB — Docker-less runs are
+  84/84). Phase 0 baseline was 66; Phase 2 added 6 InflectionsTest cases;
+  Phase 3, PR B added 4 ExposedMigrationTest cases; PR #201 added 2
+  ScriptClasspathTest cases; Phase 4 added 5 H2 cases in `core` (PR #206) and
+  the 2 integration-test cases (PR #207).
 - `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
-  + `java.sourceCompatibility/targetCompatibility = 1.8` in all three modules
-  (`core`, `exposed`, `gradle-plugin`). Verified by `javap`: all main classes are
-  class-file major **52** (JVM 8).
+  + `java.sourceCompatibility/targetCompatibility = 1.8` in all four modules
+  (`core`, `exposed`, `gradle-plugin`, `integration-test`). Verified by
+  `javap`: all main classes are class-file major **52** (JVM 8).
 - `document/` is **dropped from the root build** (`settings.gradle.kts` includes
-  only `core`, `exposed`, `gradle-plugin`). The nested Gradle 4.9 build is untouched.
+  only `core`, `exposed`, `gradle-plugin`, `integration-test`). The nested
+  Gradle 4.9 build is untouched.
 - CI replaced: `gradle.yml` + `.circleci/config.yml` → `ci.yml` +
   `jvm8-bytecode.yml` (see [ci.md](ci.md)).
 
@@ -46,6 +50,7 @@ Key references:
 | JUnit Jupiter | **DONE** | 5.4.2 → **6.1.2** (Phase 2, PR #186); see the note below on the `TargetJvmVersion` attribute override. |
 | `commons-codec` | **DONE** | 1.15 dropped — unused (PR #184). |
 | `com.github.cesarferreira:kotlin-pluralizer` | **DONE** | removed (PR #187); internal `singularize()` port, see the note below (issue #140 resolved). |
+| `com.h2database:h2` | **DONE** | **2.2.224**, `testImplementation`-only (Phase 4, PR #206) for the embedded-H2 migration/adapter tests; never published from `core`. |
 
 ### exposed
 
@@ -68,6 +73,20 @@ Key references:
 | `com.gradle.plugin-publish` | **DONE** | 0.9.10 → **2.1.1**; legacy `pluginBundle` block removed (2.x moved config into `gradlePlugin`). |
 | `org.jetbrains.dokka` | **DONE** | 0.9.17 → **2.2.0**; removed the removed `outputFormat` DSL. Docs refresh is Phase 7. |
 
+### integration-test (Phase 4, PR #207)
+
+| Dependency | Status | Notes |
+| --- | --- | --- |
+| `org.junit.jupiter:junit-jupiter` | **DONE** | 6.1.2; same `TargetJvmVersion` attribute override as `core`/`gradle-plugin` (test classpaths only, JVM 8 published). |
+| `org.xerial:sqlite-jdbc` | **DONE** | 3.45.3.0, `testImplementation`-only; embedded always-green SQLite suite in `test`. |
+| `org.postgresql:postgresql` | **DONE** | 42.7.4, `integrationTestImplementation`-only; gated suite. |
+| `com.mysql:mysql-connector-j` | **DONE** | 8.4.0, `integrationTestImplementation`-only; gated suite. |
+
+Two source sets: `test` (SQLite, runs in every `build`) and `integrationTest`
+(gated `Test` task — PostgreSQL smoke test landed in PR #207; MySQL driver is
+declared but the suite is pending; connectivity probe in `@BeforeAll` aborts
+the suite when the DB is down — no Docker required for a green build).
+
 ### document (separate subproject, excluded from the root build)
 
 | Dependency | Status | Notes |
@@ -88,8 +107,9 @@ Key references:
 
 Still open (not Phase 0):
 
-- `buildConnectionUriFromDbConfig` returns `""` for `Dbms.SQLServer` / `Dbms.H2`;
-  `SqlServerAdapter` is 100% `TODO` (Phase 5).
+- `buildConnectionUriFromDbConfig` returns `""` for `Dbms.SQLServer`;
+  `SqlServerAdapter` is 100% `TODO` (Phase 5). (`Dbms.H2` was added 2026-08-15,
+  PR #206 — `jdbc:h2:<dbName>`.)
 - Coordinates/IDs reconciliation (plugin id `harmonica`/`jarmonica` applied vs
   published; stale `META-INF/gradle-plugins/com.improve_future.harmonica.properties`
   still bundled) — Phase 6.

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -64,15 +64,16 @@ services:
   CI (`org.xerial:sqlite-jdbc` + a temp-file/`:memory:` DB) and extend the
   pattern to an always-green **Docker-free SQLite integration path** for `core`
   running in `build`'s `test` task, reusing the same env-var/config helper.
-- **H2 as the Docker-free alternative**: `Connection.buildConnectionUriFromDbConfig`
-  returns `""` for `Dbms.H2` and `SqlServerAdapter` is 100% TODO. Add H2
-  support as an embedded (no-server) DBMS alongside SQLite; defer SQL Server /
-  Oracle to a later phase (they still require services). URI and lifecycle
-  contract (mirrored in `spec/plan.md` Phase 4): in-process tests use
-  `jdbc:h2:mem:<dbName>;DB_CLOSE_DELAY=-1` with a unique `<dbName>` per test (or
-  explicit schema cleanup); TestKit tests use a file-backed URL at a unique
-  absolute path and delete the H2 DB files after all TestKit processes close;
-  the H2 driver is test/integration runtime-only, never published from `core`.
+- **H2 as the Docker-free alternative** (**DONE 2026-08-15, PR #206**):
+  `Dbms.H2` builds `jdbc:h2:<dbName>` (`mem:` prefix gives an in-memory DB);
+  `H2Adapter` is complete; the H2 driver (2.2.224) is test/integration
+  runtime-only, never published from `core`. In-memory state across rollback/
+  reconnect is preserved by keeping the connection open after a failed
+  `transaction` for H2 (no `DB_CLOSE_DELAY` needed — the original
+  `DB_CLOSE_DELAY=-1` contract was superseded); identifier case is normalized
+  from `DatabaseMetaData` (`DATABASE_TO_LOWER` supported). H2 tests live in
+  `core` (`H2MigrationTest`, `H2AdapterTest`). SQL Server / Oracle are deferred
+  to a later phase (they still require services).
 - Document start/stop and how to run the integration suite against them.
 
 ### 3. Gating (DB may be absent)
@@ -91,9 +92,10 @@ services:
   `HARMONICA_TEST_DB_REQUIRED` set only in CI turns the probe into a
   bounded-retry check that **fails** on invalid configuration, missing
   credentials, unavailable services, or skipped DB tests — never skips.
-- The always-green SQLite (and later H2) embedded tests run in `./gradlew build`
-  via the `integration-test` module's `test` task; the gated PostgreSQL/MySQL
-  suite runs via the `integrationTest` task — never in `build`.
+- The always-green embedded tests run in `./gradlew build`: SQLite via the
+  `integration-test` module's `test` task, H2 via `core`'s `test` task; the
+  gated PostgreSQL/MySQL suite runs via the `integrationTest` task — never in
+  `build`.
 
 ### 4. CI
 
@@ -101,7 +103,7 @@ services:
   containers (Postgres/MySQL) so every merge is verified against real DBs.
 - Keep a plain unit-test job as the fast path and as the JDK 8-bytecode check
   (javap major-version assertion — see [`ci.md`](ci.md)).
-- SQLite (and later H2) tests run in the fast path (no services needed).
+- SQLite and H2 tests run in the fast path (no services needed).
 - Remove/replace the legacy CircleCI config once Actions is authoritative. —
   **done** (Phase 0).
 
@@ -116,8 +118,8 @@ services:
 
 - `integration-test` module exists in this repo, ported from `harmonica_test`.
 - `docker-compose.yml` + docs committed; local run verified on this machine.
-- `./gradlew build` runs the SQLite (and later H2) embedded tests via the
-  module's `test` task and passes without Docker; `integrationTest` passes with
-  Docker.
-- SQLite (and later H2) real-DB smoke tests are part of the always-on fast path.
+- `./gradlew build` runs the SQLite (integration-test `test` task) and H2
+  (`core` `test` task) embedded tests and passes without Docker; `integrationTest`
+  passes with Docker.
+- SQLite and H2 real-DB smoke tests are part of the always-on fast path.
 - CI `db-integration` job runs DB-backed tests on every push (required mode).


### PR DESCRIPTION
Spec docs reconciled with the merged Phase 4 work (uncommitted, per the workflow). Two rounds of spec-review verification: no blockers remaining.
What changed:
- plan.md — Phase 4 status updated: item 1 (integration-test module, PR #207) and item 3 (H2, PR #206) marked DONE, item 2 partial (SQLite + gated PG smoke tests), items 4–5 pending; the DB_CLOSE_DELAY=-1 contract marked superseded by the connection-keeping choice; test counts refreshed (Phase 3 snapshot restored to 78 with a pointer to current 85); Phase 5 small list now includes #189; develop ahead count → 96.
- tech-notes.md — 85 tests / four modules; added H2 row to core deps and a new integration-test dependency table; "Still open" now lists only SQLServer (H2 landed).
- issues-triage.md — snapshot date → 2026-08-15 (still 28 open); #196 row reflects the module landing; #67 reclassified to MEDIUM.
- testing.md — stale H2 claims rewritten to match the shipped implementation (was in scope via the review finding).
- spec/README.md — snapshot, 4 modules/85 tests, harmonica_test status, Docker now installed, v5.7.0 pin.
Authoritative test count: 85 tests (73 core + 6 plugin + 4 exposed + 2 integration-test), 1 skipped (gated PG), 0 failures — Docker-less run is 84/84.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development plans, technical notes, and issue-tracking snapshots with current Phase 4 progress.
  - Documented H2 support, including embedded testing, rollback/reconnect handling, and identifier normalization.
  - Clarified SQLite and H2 fast-path testing, along with Docker-backed PostgreSQL and MySQL integration-test requirements.
  - Revised baseline metrics, test counts, milestones, issue plans, and toolchain decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->