### PR TITLE
feat: add Docker + CI DB integration suite (Phase 4 item 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,52 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build --no-daemon
+
+  db-integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.14
+        env:
+          POSTGRES_USER: developer
+          POSTGRES_PASSWORD: developer
+          POSTGRES_DB: harmonica_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U developer -d harmonica_test"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+      mysql:
+        image: mysql:8.4.11
+        env:
+          MYSQL_USER: developer
+          MYSQL_PASSWORD: developer
+          MYSQL_DATABASE: harmonica_test
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+    env:
+      HARMONICA_TEST_DB_REQUIRED: "true"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5.7.0
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run DB integration suite
+        run: ./gradlew :integration-test:integrationTest --no-daemon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  postgres:
+    image: postgres:16.14
+    environment:
+      POSTGRES_USER: developer
+      POSTGRES_PASSWORD: developer
+      POSTGRES_DB: harmonica_test
+    ports: ["5432:5432"]
+
+  mysql:
+    image: mysql:8.4.11
+    environment:
+      MYSQL_USER: developer
+      MYSQL_PASSWORD: developer
+      MYSQL_DATABASE: harmonica_test
+      MYSQL_ROOT_PASSWORD: root
+    ports: ["3306:3306"]

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/MySqlMigrationTest.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/MySqlMigrationTest.kt
@@ -43,20 +43,18 @@ class MySqlMigrationTest {
                 }.up()
             }
             assertTrue(connection.doesTableExist(tableName))
-        } finally {
-            if (connection.doesTableExist(tableName)) {
-                connection.transaction {
-                    object : AbstractMigration() {
-                        override fun down() {
-                            dropTable(tableName)
-                        }
-                    }.apply {
-                        this.connection = connection
-                    }.down()
-                }
+            connection.transaction {
+                object : AbstractMigration() {
+                    override fun down() {
+                        dropTable(tableName)
+                    }
+                }.apply {
+                    this.connection = connection
+                }.down()
             }
+            assertFalse(connection.doesTableExist(tableName))
+        } finally {
             connection.close()
         }
-        assertFalse(connection.doesTableExist(tableName))
     }
 }

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/MySqlMigrationTest.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/MySqlMigrationTest.kt
@@ -1,0 +1,62 @@
+package com.improve_future.harmonica.integration
+
+import com.improve_future.harmonica.core.AbstractMigration
+import com.improve_future.harmonica.core.Connection
+import com.improve_future.harmonica.core.Dbms
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MySqlMigrationTest {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun requireMySql() {
+            val url = "jdbc:mysql://${TestDb.mysqlHost}:${TestDb.mysqlPort}/${TestDb.mysqlDb}"
+            TestDb.requireDb(url, TestDb.mysqlUser, TestDb.mysqlPassword)
+        }
+    }
+
+    @Test
+    fun createTableAndDropTable() {
+        val tableName = "mysql_table_${UUID.randomUUID().toString().replace("-", "")}"
+        val connection = Connection.create {
+            dbms = Dbms.MySQL
+            host = TestDb.mysqlHost
+            port = TestDb.mysqlPort
+            dbName = TestDb.mysqlDb
+            user = TestDb.mysqlUser
+            password = TestDb.mysqlPassword
+        }
+        try {
+            connection.transaction {
+                object : AbstractMigration() {
+                    override fun up() {
+                        createTable(tableName) {
+                            varchar("name")
+                        }
+                    }
+                }.apply {
+                    this.connection = connection
+                }.up()
+            }
+            assertTrue(connection.doesTableExist(tableName))
+        } finally {
+            if (connection.doesTableExist(tableName)) {
+                connection.transaction {
+                    object : AbstractMigration() {
+                        override fun down() {
+                            dropTable(tableName)
+                        }
+                    }.apply {
+                        this.connection = connection
+                    }.down()
+                }
+            }
+            connection.close()
+        }
+        assertFalse(connection.doesTableExist(tableName))
+    }
+}

--- a/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/TestDb.kt
+++ b/integration-test/src/integrationTest/kotlin/com/improve_future/harmonica/integration/TestDb.kt
@@ -17,18 +17,44 @@ object TestDb {
     val mysqlUser = env("HARMONICA_TEST_MYSQL_USER", "developer")
     val mysqlPassword = env("HARMONICA_TEST_MYSQL_PASSWORD", "developer")
 
+    private val dbRequired: Boolean
+        get() = System.getenv("HARMONICA_TEST_DB_REQUIRED") == "true"
+
     private fun env(name: String, default: String): String =
         System.getenv(name) ?: default
 
     fun requireDb(url: String, user: String, password: String) {
         val previousTimeout = DriverManager.getLoginTimeout()
         try {
-            DriverManager.setLoginTimeout(2)
-            DriverManager.getConnection(url, user, password).close()
+            if (dbRequired) connectWithRetry(url, user, password)
+            else {
+                DriverManager.setLoginTimeout(2)
+                DriverManager.getConnection(url, user, password).close()
+            }
         } catch (e: SQLException) {
+            if (dbRequired) throw e
             Assumptions.abort("Database unavailable at $url: ${e.message}")
         } finally {
             DriverManager.setLoginTimeout(previousTimeout)
         }
+    }
+
+    private fun connectWithRetry(url: String, user: String, password: String) {
+        var lastError: SQLException? = null
+        repeat(10) { attempt ->
+            try {
+                DriverManager.setLoginTimeout(2)
+                DriverManager.getConnection(url, user, password).close()
+                return
+            } catch (e: SQLException) {
+                lastError = e
+                if (attempt < 9) Thread.sleep(2000)
+            }
+        }
+        throw SQLException(
+            "Required DB unreachable at $url after 10 attempts: " +
+                (lastError?.message ?: "no response"),
+            lastError
+        )
     }
 }


### PR DESCRIPTION
Phase 4 item 5 (Docker + CI): DB integration tests now run against real PostgreSQL and MySQL in GitHub Actions.

## Changes
- `docker-compose.yml` (repo root): `postgres:16.14` and `mysql:8.4.11` services (developer/developer, DB `harmonica_test`, ports 5432/3306) for local runs.
- `integration-test/.../TestDb.kt`: `requireDb` now supports required mode via `HARMONICA_TEST_DB_REQUIRED=true` — a bounded 10-attempt probe that **fails** (never skips) when the DB is unreachable, with a clear "Required DB unreachable at ..." message; the Docker-less path still aborts/skips so `./gradlew build` stays green without DBs.
- `integration-test/.../MySqlMigrationTest.kt` (new): gated create/drop smoke test mirroring the existing PostgreSQL one.
- `.github/workflows/ci.yml`: new `db-integration` job with postgres/mysql service containers (health-gated, `--no-daemon`), `HARMONICA_TEST_DB_REQUIRED=true`, running `:integration-test:integrationTest`.

## Verification (local)
- DBs up, required mode: 2/2 integration tests pass (PostgreSQL + MySQL)
- DBs up, default mode: 2/2 pass
- DBs down, default mode: 2 skipped, build green (Docker-less stays green)
- DBs down, required mode: build fails with informative error (never skips)
- `./gradlew build` green
- Reviewed by build-review agent: no blockers

Spec docs (plan/ci/testing status) will be reconciled in a follow-up PR after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for database table creation and removal with MySQL.
  * Improved database availability handling for reliable integration-test execution.
  * Added validation across both PostgreSQL and MySQL environments.

* **Chores**
  * Expanded continuous integration to run database-backed tests automatically.
  * Added a Docker Compose setup for consistent local PostgreSQL and MySQL test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->