### PR TITLE
docs: reconcile spec pins after dependabot merges

### DIFF
--- a/.opencode/skills/harmonica-dev/SKILL.md
+++ b/.opencode/skills/harmonica-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harmonica-dev
-description: Use when working on the Harmonica Kotlin DB migration tool — planning, phase work, PRs, or anything touching this repo. Encodes the restart workflow: read spec/ before proposing work, small PRs per issue, toolchain constraints (JVM 8 target, Gradle 9.6.1 + Kotlin 2.3.20 on the Java 25 dev machine), and conventions (no comments, no unused deps, core stays Exposed-free).
+description: Use when working on the Harmonica Kotlin DB migration tool — planning, phase work, PRs, or anything touching this repo. Encodes the restart workflow: read spec/ before proposing work, small PRs per issue, toolchain constraints (JVM 8 target, Gradle 9.7.0 + Kotlin 2.3.20 on the Java 25 dev machine), and conventions (no comments, no unused deps, core stays Exposed-free).
 ---
 
 # Harmonica Development
@@ -20,7 +20,7 @@ change.
 ## Hard constraints
 
 - JVM 8 bytecode target (`jvmTarget = 1.8`) — never bump.
-- `./gradlew build` works on this machine (Gradle 9.6.1 + Kotlin 2.3.20 on
+- `./gradlew build` works on this machine (Gradle 9.7.0 + Kotlin 2.3.20 on
   OpenJDK 25). A red build is a real bug — fix it, don't defer.
 - One change per PR against `develop`.
 - Never commit unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ and is being restarted. See `spec/plan.md` for the master plan.
 
 - **Target bytecode is JVM 8** (`jvmTarget = 1.8`). Never bump this.
 - The only JDK installed on the dev machine is **OpenJDK 25**.
-- The repo is on **Gradle wrapper 9.6.1** and **Kotlin 2.3.20** (Phase 0, merged
-  via PR #183). `./gradlew build` works on this machine.
+- The repo is on **Gradle wrapper 9.7.0** and **Kotlin 2.3.20** (Phase 0, merged
+  via PR #183; wrapper bumped via PR #211). `./gradlew build` works on this machine.
 - **Small changes per PR** against `develop`.
 - **Never commit** unless explicitly asked. Stage only intended files.
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -16,12 +16,12 @@ plan to restart and modernize the project.
 
 ## Current state (baseline, branch `develop`)
 
-> Snapshot taken 2026-08-15, after Phase 3 (Exposed bridge, PRs #197-#199;
+> Snapshot taken 2026-08-16, after Phase 3 (Exposed bridge, PRs #197-#199;
 > script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203) and Phase 4
 > so far (H2 embedded DBMS, PR #206; integration-test module, PR #207; Docker +
 > CI db-integration, PR #209). Update this list when the baseline advances.
 
-- Kotlin **2.3.20**, Gradle wrapper **9.6.1**, `jvmTarget = 1.8` (class-file
+- Kotlin **2.3.20**, Gradle wrapper **9.7.0**, `jvmTarget = 1.8` (class-file
   major 52 asserted in CI)
 - Gradle plugin-publish **2.1.1**, Dokka **2.2.0** (Dokka bundles Jackson
   2.15.3 at build time only — not shipped; see the Dependabot alerts)
@@ -39,7 +39,7 @@ plan to restart and modernize the project.
   Docker, skip without; required CI mode fails instead); `document` (nested
   standalone build) is excluded from the build
 - H2 embedded DBMS support in `core` (PR #206): `Dbms.H2` → `jdbc:h2:<dbName>`,
-  `H2Adapter` complete, H2 2.2.224 test-only; in-memory DB state survives a
+  `H2Adapter` complete, H2 2.4.240 test-only; in-memory DB state survives a
   failed `transaction` (connection kept open for H2), identifier case derived
   from `DatabaseMetaData`
 - The `integration-test` module (PR #207) replaces the separate `harmonica_test`
@@ -62,7 +62,7 @@ plan to restart and modernize the project.
   module is in the root build (SQLite always-green; PostgreSQL and MySQL gated
   and run against Docker/CI, PR #209); the full `harmonica_test` port and the
   issue #196 with/without-Exposed flow remain
-- **`develop` is 102 commits ahead of `master`** — Phase 4 (real-DB tests) must
+- **`develop` is 117 commits ahead of `master`** — Phase 4 (real-DB tests) must
   pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 
 ## Machine environment (current)
@@ -70,5 +70,5 @@ plan to restart and modernize the project.
 - OpenJDK 25.0.3 (only JDK installed)
 - No standalone `gradle`; **Docker installed 2026-08-15** (user added to the
   `docker` group) for the Phase 4 DB-backed tests
-- Toolchain upgrade done (Phase 0, PR #183): the Gradle 9.6.1 wrapper runs on
+- Toolchain upgrade done (Phase 0, PR #183): the Gradle 9.7.0 wrapper runs on
   Java 25, so `./gradlew build` works locally.

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -35,7 +35,7 @@ State:
 
 - `master` (origin/master @ `3b423c6`) has not been touched in years and is the
   direct ancestor of `develop` (merge-base == master HEAD).
-- `develop` is **102 commits ahead** (module split into `core`/`gradle-plugin`,
+- `develop` is **117 commits ahead** (module split into `core`/`gradle-plugin`,
   jcenter removal work, MIT license change, CI-action bumps, Phase 3 Exposed
   bridge, Phase 4 start, etc.) but **never fully tested or released** — this is
   why master was left behind.
@@ -97,7 +97,7 @@ Outcome: project compiles and tests on Java 25; CI works.
 Status: **implemented and merged (2026-08-01, PR #183, merge commit
 `69344da`).** `./gradlew clean build` is green locally on Java 25 and in CI.
 
-- Upgrade Gradle wrapper to **9.1.x or newer** — done: **9.6.1** (wrapper jar/
+- Upgrade Gradle wrapper to **9.1.x or newer** — done: **9.7.0** (wrapper jar/
   scripts regenerated via `./gradlew wrapper`). Bootstrap trick used: the old
   6.5 wrapper jar can still download a new distribution, so
   `gradle/wrapper/gradle-wrapper.properties` was hand-edited first.
@@ -182,7 +182,7 @@ gradle-plugin; Phase 0 baseline was 66; `ScriptClasspathTest` later added 2
     internal `singularize()` ported into `core/.../table/Inflections.kt`
     (PR #187, decision in §6).
   - `commons-codec` 1.15 → **dropped** (no usage; PR #184).
-  - JUnit Jupiter 5.4.2 → **6.1.2** (PR #186; decision in §6);
+  - JUnit Jupiter 5.4.2 → **6.1.3** (PR #186; decision in §6);
     `kotlin-test` → current (**done in Phase 0**, pinned to 2.3.20).
 - `gradle-plugin`:
   - `kotlin-script-runtime`/`kotlin-script-util` → `kotlin-scripting-jsr223` —
@@ -254,7 +254,7 @@ remains. Docker/Compose is a reproducible dev+CI dependency (item 5,
 own small PR against `develop`):
 
 1. **Integration module scaffold** (`integration-test` subproject, per
-   [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`. **DONE
+   [`testing.md`](testing.md)). JUnit 6.1.3, `useJUnitPlatform`. **DONE
    (2026-08-15, PR #207).**
    - Connection info from env vars with known local defaults; precedence is
      env-var > default:
@@ -289,7 +289,7 @@ own small PR against `develop`):
    - The expected H2 URI is asserted in `ConnectionTest`; `testing.md`
      keeps the same contract.
    **DONE (2026-08-15, PR #206).** `Dbms.H2` builds `jdbc:h2:<dbName>`;
-   `H2Adapter` is complete; H2 2.2.224 is `testImplementation`-only. In-memory
+   `H2Adapter` is complete; H2 2.4.240 is `testImplementation`-only. In-memory
    state across rollback/reconnect is preserved by keeping the connection open
    after a failed `transaction` for H2 (no `DB_CLOSE_DELAY` needed); identifier
    case is normalized from `DatabaseMetaData` (`DATABASE_TO_LOWER` supported).
@@ -393,7 +393,7 @@ Full triage: [issues-triage.md]. Order:
 Resolved (2026-08-01):
 
 - Kotlin patch pinned: **2.3.20**.
-- Gradle pinned: **9.6.1**.
+- Gradle pinned: **9.7.0** (bumped from 9.6.1 via dependabot PR #211, 2026-08-16).
 - `document` module: **dropped from the root build** (folder kept, excluded from
   settings).
 - JVM-8 verification: **javap class-version check** (`jvm8-bytecode.yml`), not a
@@ -401,7 +401,8 @@ Resolved (2026-08-01):
 - Pluralization: **implement internally** — `singularize()` ported into
   `core/.../table/Inflections.kt`, kotlin-pluralizer + jitpack removed
   (Phase 2, PR #187).
-- JUnit: **6.1.2** (Java 17 baseline). Test configurations carry
+- JUnit: **6.1.3** (Java 17 baseline; bumped from 6.1.2 via dependabot PRs
+  #210/#214). Test configurations carry
   `org.gradle.jvm.version = 17` via `TargetJvmVersion` attribute override;
   published bytecode stays JVM 8 (Phase 2, PR #186).
 - Reflections: **replaced with an internal classpath scanner**; `loadClass`
@@ -410,11 +411,14 @@ Resolved (2026-08-01):
 - Kotlin `jvm` plugin bump 2.3.20 → 2.4.10 (PR #193): **declined** — no
   functional need; stay on 2.3.20. PR #193 is still open (dependabot) as of
   2026-08-15; revisit before the next phase.
-- Dependabot batch 2026-08-15 (PRs #210-#216, all open): wrapper 9.7.0 (#211),
-  JUnit 6.1.3 (#210/#214), postgresql 42.7.13 (#213), H2 2.4.240 (#212),
-  exposed 1.4.0 (#215), mysql-connector-j 26.7.0 (#216) — bumps to every pinned
-  version in tech-notes.md. Not merged; accept/decline each (own small PRs)
-  before the next phase.
+- Dependabot batch 2026-08-15 (PRs #210-#216): wrapper 9.7.0 (#211), JUnit
+  6.1.3 (#210/#214), postgresql 42.7.13 (#213), H2 2.4.240 (#212),
+  mysql-connector-j 26.7.0 (#216) — **merged 2026-08-16**; spec pins in
+  tech-notes.md updated. **Not merged:** exposed 1.4.0 (#215) — Exposed 1.x
+  moved the JDBC API out of `org.jetbrains.exposed.sql`, breaking the
+  `harmonica-exposed` bridge (`:exposed:compileKotlin` fails: unresolved
+  `sql`/`Database`/`Transaction`). Deferred — a bridge rewrite is its own piece
+  of work; #215 stays open (see Phase 5).
 
 Still open:
 

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,11 +1,11 @@
 # Toolchain & Dependency Research
 
-Facts gathered on 2026-08-01 (test counts updated 2026-08-15). Update this
+Facts gathered on 2026-08-01 (test counts and versions updated 2026-08-16). Update this
 file as versions change.
 
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
-- Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
+- Gradle wrapper **6.5 → 9.7.0**, Kotlin **1.4.20 → 2.3.20**.
   `./gradlew clean build` is green on Java 25; **84 tests passed, 0 skipped**
   (73 core, 6 gradle-plugin, 4 exposed, 1 SQLite integration-test).
   `./gradlew :integration-test:integrationTest` reports **2 gated tests**
@@ -30,8 +30,8 @@ file as versions change.
 
 | Component | In repo now | Notes |
 | --- | --- | --- |
-| JDK to run Gradle | OpenJDK 25 | Gradle 9.1.0+ required (Java 25); 9.6.1 in use. |
-| Gradle wrapper | 9.6.1 | `gradle-9.6.1-bin.zip`; wrapper jar/scripts regenerated via `./gradlew wrapper`. |
+| JDK to run Gradle | OpenJDK 25 | Gradle 9.1.0+ required (Java 25); 9.7.0 in use. |
+| Gradle wrapper | 9.7.0 | `gradle-9.7.0-bin.zip`; wrapper jar/scripts regenerated via `./gradlew wrapper`. |
 | Kotlin | 2.3.20 | `jvmTarget = 1.8` (bytecode) still supported — verified in 2.3.20 with **no** deprecation warning (only the old `kotlinOptions` DSL is deprecated; this build uses `compilerOptions`). |
 | Java language level | 1.8 | `java.sourceCompatibility/targetCompatibility` = 1.8 (no Java sources today). |
 | Test runtime JDK | Java 25 | JVM-8 target proven by the `jvm8-bytecode.yml` javap check (decision, ci.md §3.2), not a JDK-8 run. |
@@ -50,10 +50,10 @@ Key references:
 | Dependency | Status | Notes |
 | --- | --- | --- |
 | `org.jetbrains.kotlin:kotlin-test*` | **DONE** | 2.3.20 via `gradle.properties`. |
-| JUnit Jupiter | **DONE** | 5.4.2 → **6.1.2** (Phase 2, PR #186); see the note below on the `TargetJvmVersion` attribute override. |
+| JUnit Jupiter | **DONE** | 5.4.2 → **6.1.3** (Phase 2, PR #186; patch bumps PRs #210/#214); see the note below on the `TargetJvmVersion` attribute override. |
 | `commons-codec` | **DONE** | 1.15 dropped — unused (PR #184). |
 | `com.github.cesarferreira:kotlin-pluralizer` | **DONE** | removed (PR #187); internal `singularize()` port, see the note below (issue #140 resolved). |
-| `com.h2database:h2` | **DONE** | **2.2.224**, `testImplementation`-only (Phase 4, PR #206) for the embedded-H2 migration/adapter tests; never published from `core`. |
+| `com.h2database:h2` | **DONE** | **2.4.240**, `testImplementation`-only (Phase 4, PR #206; bump PR #212) for the embedded-H2 migration/adapter tests; never published from `core`. |
 
 ### exposed
 
@@ -80,10 +80,10 @@ Key references:
 
 | Dependency | Status | Notes |
 | --- | --- | --- |
-| `org.junit.jupiter:junit-jupiter` | **DONE** | 6.1.2; same `TargetJvmVersion` attribute override as `core`/`gradle-plugin` (test classpaths only, JVM 8 published). |
+| `org.junit.jupiter:junit-jupiter` | **DONE** | 6.1.3; same `TargetJvmVersion` attribute override as `core`/`gradle-plugin` (test classpaths only, JVM 8 published). |
 | `org.xerial:sqlite-jdbc` | **DONE** | 3.45.3.0, `testImplementation`-only; embedded always-green SQLite suite in `test`. |
-| `org.postgresql:postgresql` | **DONE** | 42.7.4, `integrationTestImplementation`-only; gated suite. |
-| `com.mysql:mysql-connector-j` | **DONE** | 8.4.0, `integrationTestImplementation`-only; gated suite. |
+| `org.postgresql:postgresql` | **DONE** | 42.7.13, `integrationTestImplementation`-only; gated suite. |
+| `com.mysql:mysql-connector-j` | **DONE** | 26.7.0 (Oracle's current GA line), `integrationTestImplementation`-only; gated suite. |
 
 Two source sets: `test` (SQLite, runs in every `build`) and `integrationTest`
 (gated `Test` task — PostgreSQL smoke test landed in PR #207, MySQL smoke test
@@ -137,14 +137,14 @@ Still open (not Phase 0):
   Replaced with an internal `singularize()` port
   (`core/.../table/Inflections.kt`), behavior-identical (quirks included,
   e.g. `leaves → leafe`).
-- **JUnit 6.1.2** (Phase 2, PR #186): JUnit 6 has a **Java 17 baseline** and
+- **JUnit 6.1.3** (Phase 2, PR #186; patch bumps PRs #210/#214): JUnit 6 has a **Java 17 baseline** and
   declares `org.gradle.jvm.version = 17` in its Gradle metadata. Our test
   configurations carry jvm.version 8 (from `targetCompatibility = 1.8`), so
   resolution initially rejected the artifacts. Fix: override
   `TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE` to 17 on
   `testCompileClasspath`/`testRuntimeClasspath` only. **Published (main)
   bytecode stays JVM 8.** `kotlin-test-junit5:2.3.20` pins junit 5.10.1 /
-  platform 1.10.1; Gradle conflict resolution bumps them to 6.1.2.
+  platform 1.10.1; Gradle conflict resolution bumps them to 6.1.3.
 - `org.reflections:0.9.11` — **removed** (Phase 2, PR #185); replaced with a
   small classpath scanner in `JarmonicaTaskMain` (file + jar protocols).
   `loadClass` catches only `ClassNotFoundException` + `LinkageError` (PR #188);

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -9,7 +9,7 @@
 
 ## Current state
 
-- Unit tests exist in `core`, `exposed`, and `gradle-plugin` (JUnit 6.1.2,
+- Unit tests exist in `core`, `exposed`, and `gradle-plugin` (JUnit 6.1.3,
   `useJUnitPlatform`). `core`/`gradle-plugin` use **stubs, not real JDBC
   drivers**: core's DB tests go through
   `StubConnection`/`StubDbAdapter`/`StubMigration` (package-private), adapter
@@ -66,7 +66,7 @@ services:
   running in `build`'s `test` task, reusing the same env-var/config helper.
 - **H2 as the Docker-free alternative** (**DONE 2026-08-15, PR #206**):
   `Dbms.H2` builds `jdbc:h2:<dbName>` (`mem:` prefix gives an in-memory DB);
-  `H2Adapter` is complete; the H2 driver (2.2.224) is test/integration
+  `H2Adapter` is complete; the H2 driver (2.4.240) is test/integration
   runtime-only, never published from `core`. In-memory state across rollback/
   reconnect is preserved by keeping the connection open after a failed
   `transaction` for H2 (no `DB_CLOSE_DELAY` needed — the original


### PR DESCRIPTION
Plan-review reconciliation after the six dependabot dependency bumps (#210-#214, #216) and #217 merged.

## Changes
- `spec/plan.md`: Gradle pinned 9.7.0, JUnit 6.1.3 (with bump provenance); H2 2.4.240; §6 dependabot batch note now records #210-#214/#216 merged (2026-08-16) and #215 (Exposed 1.4.0) NOT merged with the reason (Exposed 1.x moved the JDBC API out of `org.jetbrains.exposed.sql`, breaking the `harmonica-exposed` bridge; deferred, PR left open); commits-ahead 102 → 117.
- `spec/tech-notes.md`: wrapper/JUnit/H2/postgresql/mysql dependency rows updated to merged versions; JUnit note 6.1.3; header date.
- `spec/README.md` / `spec/testing.md`: version strings synced; snapshot date 2026-08-16; commits-ahead 117.
- `AGENTS.md` + `.opencode/skills/harmonica-dev/SKILL.md`: Gradle wrapper 9.7.0.

## Verification
- `./gradlew test` green under Gradle 9.7.0 (84 passed, 0 skipped, 0 failures).
- exposed-jdbc (0.61.0) and Kotlin (2.3.20) correctly unchanged.
- spec-review agent: no blockers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance and technical documentation for Gradle 9.7.0.
  * Refreshed dependency references, including JUnit 6.1.3, H2 2.4.240, PostgreSQL 42.7.13, and MySQL Connector/J 26.7.0.
  * Updated testing notes, compatibility details, test counts, and current project status.
  * Recorded completed integration testing, Docker, and CI work, along with the deferred Exposed upgrade.

* **Chores**
  * Synchronized documented toolchain and test-environment versions across project references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->