### PR TITLE
Plugin-flow TestKit tests (issue #196)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
+group = "com.improve_future"
+version = "2.0.0"
+
 repositories {
     mavenCentral()
 }

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -1,0 +1,29 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.xerial:sqlite-jdbc:3.45.3.0")
+        classpath("org.postgresql:postgresql:42.7.13")
+        classpath("com.mysql:mysql-connector-j:26.7.0")
+    }
+}
+
+plugins {
+    kotlin("jvm") version "2.3.20"
+    id("harmonica") version "2.0.0"
+    id("jarmonica") version "2.0.0"
+}
+
+extra["directoryPath"] = "src/main/kotlin/com/improve_future/harmonica/demo/script"
+extra["migrationPackage"] = "com.improve_future.harmonica.demo.jarmonica"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.improve_future:gradle-plugin:2.0.0")
+    harmonica("com.improve_future:exposed:2.0.0")
+    implementation("org.xerial:sqlite-jdbc:3.45.3.0")
+}

--- a/demo/settings.gradle.kts
+++ b/demo/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("..")
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "harmonica-demo"
+includeBuild("..")

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/config/Default.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/config/Default.kt
@@ -1,0 +1,12 @@
+package com.improve_future.harmonica.demo.jarmonica.config
+
+import com.improve_future.harmonica.core.DbConfig
+import com.improve_future.harmonica.core.Dbms
+
+class Default : DbConfig({
+    dbms = Dbms.PostgreSQL
+    user = "developer"
+    password = "developer"
+    host = "127.0.0.1"
+    dbName = "harmonica_demo"
+})

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/config/MySql.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/config/MySql.kt
@@ -1,0 +1,13 @@
+package com.improve_future.harmonica.demo.jarmonica.config
+
+import com.improve_future.harmonica.core.DbConfig
+import com.improve_future.harmonica.core.Dbms
+
+class MySql : DbConfig({
+    dbms = Dbms.MySQL
+    user = "developer"
+    password = "developer"
+    host = "127.0.0.1"
+    dbName = "harmonica_demo"
+    port = 3306
+})

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/config/Sqlite.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/config/Sqlite.kt
@@ -1,0 +1,9 @@
+package com.improve_future.harmonica.demo.jarmonica.config
+
+import com.improve_future.harmonica.core.DbConfig
+import com.improve_future.harmonica.core.Dbms
+
+class Sqlite : DbConfig({
+    dbms = Dbms.SQLite
+    dbName = "harmonica_demo"
+})

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714192339748_NormalMigration.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714192339748_NormalMigration.kt
@@ -1,0 +1,40 @@
+package com.improve_future.harmonica.demo.jarmonica.migration
+
+import com.improve_future.harmonica.core.AbstractMigration
+
+class M20180714192339748_NormalMigration : AbstractMigration() {
+    override fun up() {
+        createTable("normal_table") {
+            integer("integer_column")
+            varchar("varchar_column")
+            decimal("decimal_column")
+            boolean("boolean_column")
+            blob("blob_column")
+            date("date_column")
+            time("time_column")
+            dateTime("date_time_column")
+            timestamp("timestamp_column")
+            text("text_column")
+        }
+        val tableName = "normal_table_for_add"
+        createTable(tableName) {}
+        addIntegerColumn(tableName, "integer_column")
+        addVarcharColumn(tableName, "varchar_column")
+        addDecimalColumn(tableName, "decimal_column")
+        addBooleanColumn(tableName, "boolean_column")
+        addBlobColumn(tableName, "blob_column")
+        addDateColumn(tableName, "date_column")
+        addTimeColumn(tableName, "time_column")
+        addDateTimeColumn(tableName, "date_time_column")
+        addTimestampColumn(tableName, "timestamp_column")
+        addTextColumn(tableName, "text_column")
+
+        createIndex("normal_table", "integer_column")
+    }
+
+    override fun down() {
+        dropIndex("normal_table", "normal_table_integer_column_idx")
+        dropTable("normal_table_for_add")
+        dropTable("normal_table")
+    }
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714194338790_NotNullMigration.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714194338790_NotNullMigration.kt
@@ -1,0 +1,42 @@
+package com.improve_future.harmonica.demo.jarmonica.migration
+
+import com.improve_future.harmonica.core.AbstractMigration
+
+class M20180714194338790_NotNullMigration : AbstractMigration() {
+    override fun up() {
+        createTable("not_null_table") {
+            integer("integer_column", nullable = false)
+            varchar("varchar_column", nullable = false)
+            decimal("decimal_column", nullable = false)
+            boolean("boolean_column", nullable = false)
+            blob("blob_column", nullable = false)
+            date("date_column", nullable = false)
+            time("time_column", nullable = false)
+            dateTime("date_time_column", nullable = false)
+            timestamp("timestamp_column", nullable = false)
+            text("text_column", nullable = false)
+            refer("normal_table")
+        }
+        val tableName = "not_null_table_for_add"
+        createTable(tableName) {}
+        addIntegerColumn(tableName, "integer_column", nullable = false)
+        addVarcharColumn(tableName, "varchar_column", nullable = false)
+        addDecimalColumn(tableName, "decimal_column", nullable = false)
+        addBooleanColumn(tableName, "boolean_column", nullable = false)
+        addBlobColumn(tableName, "blob_column", nullable = false)
+        addDateColumn(tableName, "date_column", nullable = false)
+        addTimeColumn(tableName, "time_column", nullable = false)
+        addDateTimeColumn(tableName, "date_time_column", nullable = false)
+        addTimestampColumn(tableName, "timestamp_column", nullable = false)
+        addTextColumn(tableName, "text_column", nullable = false)
+        addForeignKey(
+            "not_null_table_for_add", "integer_column",
+            "normal_table_for_add"
+        )
+    }
+
+    override fun down() {
+        dropTable("not_null_table_for_add")
+        dropTable("not_null_table")
+    }
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714194840311_DefaultMigration.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714194840311_DefaultMigration.kt
@@ -1,0 +1,69 @@
+package com.improve_future.harmonica.demo.jarmonica.migration
+
+import com.improve_future.harmonica.core.AbstractMigration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.Date
+
+class M20180714194840311_DefaultMigration : AbstractMigration() {
+    override fun up() {
+        createTable("default_table") {
+            integer("integer_column", default = 1)
+            varchar("varchar_column", default = "text")
+            decimal("decimal_column", default = 1.1)
+            boolean("boolean_column", default = true)
+            blob("blob_column", default = "abcdefg".toByteArray())
+            date("date_column_1", default = Date())
+            date("date_column_2", default = LocalDate.now())
+            date("date_column_3", default = "2018-01-02")
+            time("time_column_1", default = "11:22:33")
+            time("time_column_2", default = Date())
+            time("time_column_3", default = LocalTime.now())
+            dateTime("date_time_column_1", default = "2011-11-12 12:34:56")
+            dateTime("date_time_column_2", default = Date())
+            dateTime("date_time_column_3", default = LocalDateTime.now())
+            timestamp("timestamp_column_1", default = "2012-10-04 1:2:3")
+            timestamp("timestamp_column_2", default = Date())
+            timestamp("timestamp_column_3", default = LocalDateTime.now())
+            text("text_column", default = "text")
+        }
+        val tableName = "default_table_for_add"
+        createTable(tableName) {}
+        addIntegerColumn(tableName, "integer_column", default = 1)
+        addVarcharColumn(tableName, "varchar_column", default = "text")
+        addDecimalColumn(tableName, "decimal_column", default = 1.1)
+        addBooleanColumn(tableName, "boolean_column", default = false)
+        addBlobColumn(tableName, "blob_column", default = "abcdefg".toByteArray())
+        addDateColumn(tableName, "date_column_1", default = Date())
+        addDateColumn(tableName, "date_column_2", default = LocalDate.now())
+        addDateColumn(tableName, "date_column_3", default = "2018-01-02")
+        addTimeColumn(tableName, "time_column_1", default = "11:22:33")
+        addTimeColumn(tableName, "time_column_2", default = Date())
+        addTimeColumn(tableName, "time_column_3", default = LocalTime.now())
+        addDateTimeColumn(
+            tableName, "date_time_column_1", default = "2011-11-12 12:34:56"
+        )
+        addDateTimeColumn(
+            tableName, "date_time_column_2", default = Date()
+        )
+        addDateTimeColumn(
+            tableName, "date_time_column_3", default = LocalDateTime.now()
+        )
+        addTimestampColumn(
+            tableName, "timestamp_column_1", default = "2012-10-04 1:2:3"
+        )
+        addTimestampColumn(
+            tableName, "timestamp_column_2", default = Date()
+        )
+        addTimestampColumn(
+            tableName, "timestamp_column_3", default = LocalDateTime.now()
+        )
+        addTextColumn(tableName, "text_column", default = "text")
+    }
+
+    override fun down() {
+        dropTable("default_table_for_add")
+        dropTable("default_table")
+    }
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714203511949_OtherMigration.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714203511949_OtherMigration.kt
@@ -24,6 +24,7 @@ class M20180714203511949_OtherMigration : AbstractMigration() {
             tableName, "decimal_column", precision = 5, scale = 2
         )
         addBooleanColumn(tableName, "boolean_column")
+        addBlobColumn(tableName, "blob_column")
         addDateColumn(tableName, "date_column")
         addTimeColumn(tableName, "time_column", withTimeZone = true)
         addDateTimeColumn(tableName, "date_time_column")

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714203511949_OtherMigration.kt
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/jarmonica/migration/M20180714203511949_OtherMigration.kt
@@ -1,0 +1,38 @@
+package com.improve_future.harmonica.demo.jarmonica.migration
+
+import com.improve_future.harmonica.core.AbstractMigration
+
+class M20180714203511949_OtherMigration : AbstractMigration() {
+    override fun up() {
+        createTable("other_table") {
+            integer("integer_column")
+            varchar("varchar_column", size = 1)
+            decimal("decimal_column", 5, 2)
+            boolean("boolean_column")
+            blob("blob_column")
+            date("date_column")
+            time("time_column", withTimeZone = true)
+            dateTime("date_time_column")
+            timestamp("timestamp_column", withTimeZone = true)
+            text("text_column")
+        }
+        val tableName = "other_table_for_add"
+        createTable(tableName) {}
+        addIntegerColumn(tableName, "integer_column")
+        addVarcharColumn(tableName, "varchar_column", size = 1)
+        addDecimalColumn(
+            tableName, "decimal_column", precision = 5, scale = 2
+        )
+        addBooleanColumn(tableName, "boolean_column")
+        addDateColumn(tableName, "date_column")
+        addTimeColumn(tableName, "time_column", withTimeZone = true)
+        addDateTimeColumn(tableName, "date_time_column")
+        addTimestampColumn(tableName, "timestamp_column", withTimeZone = true)
+        addTextColumn(tableName, "text_column")
+    }
+
+    override fun down() {
+        dropTable("other_table_for_add")
+        dropTable("other_table")
+    }
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/config/default.kts
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/config/default.kts
@@ -1,0 +1,10 @@
+import com.improve_future.harmonica.core.DbConfig
+import com.improve_future.harmonica.core.Dbms
+
+DbConfig {
+    dbms = Dbms.PostgreSQL
+    user = "developer"
+    password = "developer"
+    host = "127.0.0.1"
+    dbName = "harmonica_demo"
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/config/mysql.kts
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/config/mysql.kts
@@ -1,0 +1,11 @@
+import com.improve_future.harmonica.core.DbConfig
+import com.improve_future.harmonica.core.Dbms
+
+DbConfig {
+    dbms = Dbms.MySQL
+    user = "developer"
+    password = "developer"
+    host = "127.0.0.1"
+    dbName = "harmonica_demo"
+    port = 3306
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/config/sqlite.kts
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/config/sqlite.kts
@@ -1,0 +1,7 @@
+import com.improve_future.harmonica.core.DbConfig
+import com.improve_future.harmonica.core.Dbms
+
+DbConfig {
+    dbms = Dbms.SQLite
+    dbName = "harmonica_demo"
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/migration/20260811000000_ExposedDemo.kts
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/migration/20260811000000_ExposedDemo.kts
@@ -1,0 +1,28 @@
+import com.improve_future.harmonica.core.AbstractMigration
+import com.improve_future.harmonica.exposed.exposedTransaction
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+
+object DemoExposedTable : Table("demo_exposed") {
+    val id = integer("id").autoIncrement()
+    val name = varchar("name", 100)
+    override val primaryKey = PrimaryKey(id)
+}
+
+object : AbstractMigration() {
+    override fun up() {
+        exposedTransaction {
+            SchemaUtils.create(DemoExposedTable)
+            DemoExposedTable.insert { it[name] = "harmonica" }
+            println("exposed rows: " + DemoExposedTable.selectAll().count())
+        }
+    }
+
+    override fun down() {
+        exposedTransaction {
+            SchemaUtils.drop(DemoExposedTable)
+        }
+    }
+}

--- a/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/migration/20260811000001_PlainDemo.kts
+++ b/demo/src/main/kotlin/com/improve_future/harmonica/demo/script/migration/20260811000001_PlainDemo.kts
@@ -1,0 +1,14 @@
+import com.improve_future.harmonica.core.AbstractMigration
+
+object : AbstractMigration() {
+    override fun up() {
+        createTable("demo_plain") {
+            varchar("name")
+        }
+        executeSql("INSERT INTO demo_plain (name) VALUES ('harmonica')")
+    }
+
+    override fun down() {
+        dropTable("demo_plain")
+    }
+}

--- a/exposed/build.gradle.kts
+++ b/exposed/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
+group = "com.improve_future"
+version = "2.0.0"
+
 repositories {
     mavenCentral()
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     // Dependencies to be able to run tests within gradle
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.3")
+    testImplementation(gradleTestKit())
+    testImplementation("org.xerial:sqlite-jdbc:3.45.3.0")
 
     //implementation localGroovy()  // Groovy SDK
     compileOnly(gradleApi())

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -57,6 +58,9 @@ kotlin {
 tasks {
     test {
         useJUnitPlatform()
+        testLogging {
+            exceptionFormat = TestExceptionFormat.FULL
+        }
     }
 
     task<Jar>("sourcesJar") {

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractMigrationTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractMigrationTask.kt
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.net.URLClassLoader
-import java.nio.file.Paths
 
 @DisableCachingByDefault(because = "Migration tasks execute user-provided scripts")
 abstract class AbstractMigrationTask : AbstractTask() {
@@ -35,7 +34,7 @@ abstract class AbstractMigrationTask : AbstractTask() {
     }
 
     private fun findConfigFile(): File {
-        return Paths.get(directoryPath, "config", "$env.kts").toFile()
+        return resolvePath(directoryPath).resolve("config").resolve("$env.kts")
     }
 
     fun loadConfigFile(): DbConfig {

--- a/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/improve_future/harmonica/plugin/AbstractTask.kt
@@ -28,7 +28,12 @@ abstract class AbstractTask : DefaultTask() {
         }
 
     fun findMigrationDir(): File {
-        return Paths.get(directoryPath, "migration").toFile()
+        return resolvePath(directoryPath).resolve("migration")
+    }
+
+    protected fun resolvePath(path: String): File {
+        val asPath = Paths.get(path)
+        return if (asPath.isAbsolute) asPath.toFile() else project.file(path)
     }
 
     /** The table name to store executed migration version IDs. */

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
@@ -1,0 +1,208 @@
+package com.improve_future.harmonica.plugin
+
+import com.improve_future.harmonica.core.Connection
+import com.improve_future.harmonica.core.Dbms
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PluginFlowTest {
+    @Test
+    fun harmonicaUpAndDownWithoutExposed() {
+        val projectDir = createProject(
+            "without-exposed",
+            migrationFileName = "20260811000001_PlainDemo.kts",
+            migrationScript = plainMigration,
+            withExposed = false
+        )
+        harmonicaUp(projectDir)
+        assertMigrated(projectDir, "demo_plain", "20260811000001", migrated = true)
+        harmonicaDown(projectDir)
+        assertMigrated(projectDir, "demo_plain", "20260811000001", migrated = false)
+    }
+
+    @Test
+    fun harmonicaUpAndDownWithExposed() {
+        val projectDir = createProject(
+            "with-exposed",
+            migrationFileName = "20260811000000_ExposedDemo.kts",
+            migrationScript = exposedMigration,
+            withExposed = true
+        )
+        harmonicaUp(projectDir)
+        assertMigrated(projectDir, "demo_exposed", "20260811000000", migrated = true)
+        harmonicaDown(projectDir)
+        assertMigrated(projectDir, "demo_exposed", "20260811000000", migrated = false)
+    }
+
+    private fun createProject(
+        name: String,
+        migrationFileName: String,
+        migrationScript: String,
+        withExposed: Boolean
+    ): File {
+        val projectDir = File(File("build", "testkit"), name).apply { mkdirs() }
+        val dbPath = File(projectDir, "build/harmonica").absolutePath
+        for (suffix in listOf(".db", ".db-wal", ".db-shm")) {
+            File("$dbPath$suffix").delete()
+        }
+
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                includeBuild(${repoRoot.invariantSeparatorsPath.quoted()})
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+            rootProject.name = "plugin-flow"
+            includeBuild(${repoRoot.invariantSeparatorsPath.quoted()})
+            """.trimIndent()
+        )
+
+        val buildScript = StringBuilder().apply {
+            appendLine("buildscript {")
+            appendLine("    repositories {")
+            appendLine("        mavenCentral()")
+            appendLine("    }")
+            appendLine("    dependencies {")
+            appendLine("        classpath(\"org.xerial:sqlite-jdbc:3.45.3.0\")")
+            appendLine("    }")
+            appendLine("}")
+            appendLine("plugins {")
+            appendLine("    id(\"harmonica\") version \"2.0.0\"")
+            appendLine("}")
+            appendLine("repositories {")
+            appendLine("    mavenCentral()")
+            appendLine("}")
+            if (withExposed) {
+                appendLine("dependencies {")
+                appendLine("    harmonica(\"com.improve_future:exposed:2.0.0\")")
+                appendLine("}")
+            }
+        }.toString()
+        File(projectDir, "build.gradle.kts").writeText(buildScript)
+
+        File(projectDir, "src/main/kotlin/db/config/default.kts").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                import com.improve_future.harmonica.core.DbConfig
+                import com.improve_future.harmonica.core.Dbms
+
+                DbConfig {
+                    dbms = Dbms.SQLite
+                    dbName = ${dbPath.quoted()}
+                }
+                """.trimIndent()
+            )
+        }
+        File(projectDir, "src/main/kotlin/db/migration/$migrationFileName").apply {
+            parentFile.mkdirs()
+            writeText(migrationScript)
+        }
+        return projectDir
+    }
+
+    private fun harmonicaUp(projectDir: File) = runGradle(projectDir, "harmonicaUp")
+
+    private fun harmonicaDown(projectDir: File) = runGradle(projectDir, "harmonicaDown")
+
+    private fun runGradle(projectDir: File, vararg tasks: String) {
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*tasks)
+            .build()
+        for (task in tasks) {
+            assertEquals(TaskOutcome.SUCCESS, result.task(":$task")?.outcome, "Task :$task")
+        }
+    }
+
+    private fun assertMigrated(
+        projectDir: File, tableName: String, version: String, migrated: Boolean
+    ) {
+        val dbPath = File(projectDir, "build/harmonica").absolutePath
+        Connection.create {
+            dbms = Dbms.SQLite
+            dbName = dbPath
+            user = ""
+            password = ""
+        }.use { connection ->
+            connection.transaction {
+                assertEquals(migrated, connection.doesTableExist(tableName), tableName)
+                val count = connection.createStatement().use { statement ->
+                    statement.executeQuery(
+                        "SELECT COUNT(1) FROM harmonica_migration WHERE version = '$version'"
+                    ).use { resultSet ->
+                        resultSet.next()
+                        resultSet.getLong(1)
+                    }
+                }
+                assertEquals(if (migrated) 1L else 0L, count, "harmonica_migration rows")
+            }
+        }
+    }
+
+    private fun String.quoted() = "\"$this\""
+
+    companion object {
+        private val repoRoot: File = File("..").canonicalFile.also {
+            check(File(it, "settings.gradle.kts").exists()) {
+                "Expected the repository root at $it; the test working directory must be the gradle-plugin module"
+            }
+        }
+
+        private val plainMigration = """
+            import com.improve_future.harmonica.core.AbstractMigration
+
+            object : AbstractMigration() {
+                override fun up() {
+                    createTable("demo_plain") {
+                        varchar("name")
+                    }
+                    executeSql("INSERT INTO demo_plain (name) VALUES ('harmonica')")
+                }
+
+                override fun down() {
+                    dropTable("demo_plain")
+                }
+            }
+        """.trimIndent()
+
+        private val exposedMigration = """
+            import com.improve_future.harmonica.core.AbstractMigration
+            import com.improve_future.harmonica.exposed.exposedTransaction
+            import org.jetbrains.exposed.sql.SchemaUtils
+            import org.jetbrains.exposed.sql.Table
+            import org.jetbrains.exposed.sql.insert
+            import org.jetbrains.exposed.sql.selectAll
+
+            object DemoExposedTable : Table("demo_exposed") {
+                val id = integer("id").autoIncrement()
+                val name = varchar("name", 100)
+                override val primaryKey = PrimaryKey(id)
+            }
+
+            object : AbstractMigration() {
+                override fun up() {
+                    exposedTransaction {
+                        SchemaUtils.create(DemoExposedTable)
+                        DemoExposedTable.insert { it[name] = "harmonica" }
+                        println("exposed rows: " + DemoExposedTable.selectAll().count())
+                    }
+                }
+
+                override fun down() {
+                    exposedTransaction {
+                        SchemaUtils.drop(DemoExposedTable)
+                    }
+                }
+            }
+        """.trimIndent()
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
@@ -48,6 +48,7 @@ class PluginFlowTest {
     ): File {
         val projectDir = File(File("build", "testkit"), name).apply { mkdirs() }
         val dbPath = File(projectDir, "build/harmonica").absolutePath
+        File(dbPath).parentFile!!.mkdirs()
         for (suffix in listOf(".db", ".db-wal", ".db-shm")) {
             File("$dbPath$suffix").delete()
         }

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
@@ -4,6 +4,7 @@ import com.improve_future.harmonica.core.Connection
 import com.improve_future.harmonica.core.Dbms
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
@@ -114,10 +115,14 @@ class PluginFlowTest {
     private fun harmonicaDown(projectDir: File) = runGradle(projectDir, "harmonicaDown")
 
     private fun runGradle(projectDir: File, vararg tasks: String) {
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments(*tasks)
-            .build()
+        val result = try {
+            GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments(*tasks)
+                .build()
+        } catch (e: UnexpectedBuildFailure) {
+            throw AssertionError("Nested build ${tasks.joinToString(" ")} failed:\n${e.message}", e)
+        }
         for (task in tasks) {
             assertEquals(TaskOutcome.SUCCESS, result.task(":$task")?.outcome, "Task :$task")
         }

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
@@ -47,7 +47,7 @@ class PluginFlowTest {
         withExposed: Boolean
     ): File {
         val projectDir = File(File("build", "testkit"), name).apply { mkdirs() }
-        val dbPath = File(projectDir, "build/harmonica").absolutePath
+        val dbPath = dbPath(projectDir)
         File(dbPath).parentFile!!.mkdirs()
         for (suffix in listOf(".db", ".db-wal", ".db-shm")) {
             File("$dbPath$suffix").delete()
@@ -132,7 +132,7 @@ class PluginFlowTest {
     private fun assertMigrated(
         projectDir: File, tableName: String, version: String, migrated: Boolean
     ) {
-        val dbPath = File(projectDir, "build/harmonica").absolutePath
+        val dbPath = dbPath(projectDir)
         Connection.create {
             dbms = Dbms.SQLite
             dbName = dbPath
@@ -153,6 +153,9 @@ class PluginFlowTest {
             }
         }
     }
+
+    private fun dbPath(projectDir: File) =
+        File(projectDir, "build/harmonica").absolutePath.replace("\\", "/")
 
     private fun String.quoted() = "\"$this\""
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,7 +19,8 @@ plan to restart and modernize the project.
 > Snapshot taken 2026-08-15, after Phase 3 (Exposed bridge, PRs #197-#199;
 > script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203) and Phase 4
 > so far (H2 embedded DBMS, PR #206; integration-test module, PR #207; Docker +
-> CI db-integration, PR #209). Update this list when the baseline advances.
+> CI db-integration, PR #209; plugin-flow TestKit tests, PR #219). Update this
+> list when the baseline advances.
 
 - Kotlin **2.3.20**, Gradle wrapper **9.6.1**, `jvmTarget = 1.8` (class-file
   major 52 asserted in CI)
@@ -33,7 +34,7 @@ plan to restart and modernize the project.
   `actions/setup-java@v5.7.0`), `jvm8-bytecode.yml` (major-52 assertion),
   `dependency-submit.yml` (dependency-graph submission). CircleCI removed.
 - Four active modules: `core`, `exposed`, `gradle-plugin`, `integration-test` —
-  `./gradlew build` runs **84 tests, 0 skipped** (73 core + 6 plugin + 4 exposed
+  `./gradlew build` runs **86 tests, 0 skipped** (73 core + 8 plugin + 4 exposed
   + 1 SQLite integration-test); the **2 gated** PostgreSQL + MySQL
   integration-test cases run via `:integration-test:integrationTest` (pass with
   Docker, skip without; required CI mode fails instead); `document` (nested
@@ -60,8 +61,9 @@ plan to restart and modernize the project.
   [`exposed-integration.md`](exposed-integration.md)
 - Tests for real DBMS are being merged in Phase 4: the `integration-test`
   module is in the root build (SQLite always-green; PostgreSQL and MySQL gated
-  and run against Docker/CI, PR #209); the full `harmonica_test` port and the
-  issue #196 with/without-Exposed flow remain
+  and run against Docker/CI, PR #209); the plugin-flow TestKit tests (PR #219)
+  verify the issue #196 with/without-Exposed migration flow; the full
+  `harmonica_test` port remains
 - **`develop` is 102 commits ahead of `master`** — Phase 4 (real-DB tests) must
   pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,7 +19,7 @@ plan to restart and modernize the project.
 > Snapshot taken 2026-08-16, after Phase 3 (Exposed bridge, PRs #197-#199;
 > script-classpath wiring, PRs #201/#202; `bin/gw` tooling, PR #203) and Phase 4
 > so far (H2 embedded DBMS, PR #206; integration-test module, PR #207; Docker +
-> CI db-integration, PR #209; plugin-flow TestKit tests, PR #219). Update this
+> CI db-integration, PR #209). Update this
 > list when the baseline advances.
 
 - Kotlin **2.3.20**, Gradle wrapper **9.7.0**, `jvmTarget = 1.8` (class-file

--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -26,7 +26,7 @@ superseded by Phase 0.
 | # | Title | Plan |
 | --- | --- | --- |
 | 189 | `isSubtypeOf` in scanner swallows all `Throwable` | Narrow to recoverable exceptions to match `loadClass` (PR #188); small fix in `JarmonicaTaskMain`. |
-| 196 | Real-DB tests must cover both configs: with and without Exposed | Phase 4 item 4 (plugin-flow TestKit tests). The `integration-test` module landed (PR #207) with SQLite + gated PostgreSQL smoke tests, plus a gated MySQL smoke test (PR #209), but the with/without-`harmonica-exposed` migration-flow verification is still pending. |
+| 196 | Real-DB tests must cover both configs: with and without Exposed | Phase 4 item 4 (plugin-flow TestKit tests). The `integration-test` module landed (PR #207) with SQLite + gated PostgreSQL smoke tests, plus a gated MySQL smoke test (PR #209); the with/without-`harmonica-exposed` migration-flow verification shipped as the plugin-flow TestKit tests (PR #219) — flow verified, GitHub issue still open pending closure. |
 | 182 | README JitPack badge shows nothing | Fix JitPack badge so it renders (README badge URLs fixed in PR #181, but this badge still broken). |
 | 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
 | 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -244,14 +244,14 @@ Plan:
 
 Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
 
-**Status: in progress (2026-08-15).** Items 1 (integration-test module, PR `#207`),
-3 (H2 embedded path, PR `#206`) and 5 (Docker + CI, PR `#209`) have landed;
-item 2 is partially landed (SQLite always-green smoke test + gated PostgreSQL
+**Status: in progress (2026-08-17).** Items 1 (integration-test module, PR `#207`),
+3 (H2 embedded path, PR `#206`), 5 (Docker + CI, PR `#209`) and 4 (plugin-flow
+TestKit tests, PR `#219`) have landed; item 2 is partially landed (SQLite
+always-green smoke test + gated PostgreSQL
 smoke test in PR #207, gated MySQL smoke test in PR #209; the full
-`harmonica_test` port is still pending). Item 4 (plugin-flow TestKit tests)
-remains. Docker/Compose is a reproducible dev+CI dependency (item 5,
-[`ci.md`](ci.md) §3.1), not a machine-local detail. Breakdown (each item is its
-own small PR against `develop`):
+`harmonica_test` port is still pending). Docker/Compose is a reproducible
+dev+CI dependency (item 5, [`ci.md`](ci.md) §3.1), not a machine-local detail.
+Breakdown (each item is its own small PR against `develop`):
 
 1. **Integration module scaffold** (`integration-test` subproject, per
    [`testing.md`](testing.md)). JUnit 6.1.2, `useJUnitPlatform`. **DONE
@@ -299,6 +299,20 @@ own small PR against `develop`):
    up/down tasks against a real DB **with and without** `harmonica-exposed` on
    the script classpath. Seeds from the local `demo/` scratch project (rewritten
    for the direct scripting host), which gets committed here.
+   **DONE (2026-08-17, PR #219):** `PluginFlowTest` (gradle-plugin, `test`
+   source set, always-green) spawns real Gradle builds via TestKit that apply
+   the `harmonica` plugin from a composite `includeBuild` of the repo root and
+   run `harmonicaUp`/`harmonicaDown` against an embedded SQLite DB (absolute
+   path in `<projectDir>/build/`); one case has `harmonica("com.improve_future:exposed:2.0.0")`
+   on the script classpath (Exposed migration), one does not (plain JDBC
+   migration). Assertions check `harmonica_migration` version rows + table
+   existence. The `demo/` project is committed as the seed (script/ + jarmonica/
+   trees, no wrapper, drivers on the buildscript classpath). This PR also set
+   `group`/`version` (com.improve_future:2.0.0) on `core`/`exposed` so the
+   composite substitutes the `com.improve_future:*` coordinates, and fixed a
+   real bug: migration/config paths are now resolved relative to the project
+   directory (were relative to the daemon JVM cwd → `FileNotFoundException`
+   from TestKit).
 5. **Docker + CI** — `docker-compose.yml` at the repo root (postgres:16,
    mysql:8, `developer`/`developer`, DB `harmonica_test`); a `db-integration`
    CI job runs the gated suite against Postgres/MySQL service containers in
@@ -329,7 +343,7 @@ Definition of done:
 - Postgres + MySQL suites green locally (Docker) and in CI (the `db-integration`
   service-container job, required mode).
 - Issue #196 satisfied — the migration flow is verified with and without
-  `harmonica-exposed` on the classpath.
+  `harmonica-exposed` on the classpath (plugin-flow TestKit tests, PR #219).
 
 ### Phase 5 — Issue backlog (quick wins first)
 

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -245,9 +245,9 @@ Plan:
 Outcome: real-DB integration tests live in this repo; runnable locally and in CI.
 
 **Status: in progress (2026-08-17).** Items 1 (integration-test module, PR `#207`),
-3 (H2 embedded path, PR `#206`), 5 (Docker + CI, PR `#209`) and 4 (plugin-flow
-TestKit tests, PR `#219`) have landed; item 2 is partially landed (SQLite
-always-green smoke test + gated PostgreSQL
+3 (H2 embedded path, PR `#206`) and 5 (Docker + CI, PR `#209`) have landed;
+item 4 (plugin-flow TestKit tests) lands in PR `#219` (open); item 2 is
+partially landed (SQLite always-green smoke test + gated PostgreSQL
 smoke test in PR #207, gated MySQL smoke test in PR #209; the full
 `harmonica_test` port is still pending). Docker/Compose is a reproducible
 dev+CI dependency (item 5, [`ci.md`](ci.md) §3.1), not a machine-local detail.
@@ -299,7 +299,7 @@ Breakdown (each item is its own small PR against `develop`):
    up/down tasks against a real DB **with and without** `harmonica-exposed` on
    the script classpath. Seeds from the local `demo/` scratch project (rewritten
    for the direct scripting host), which gets committed here.
-   **DONE (2026-08-17, PR #219):** `PluginFlowTest` (gradle-plugin, `test`
+   **PR #219 (2026-08-17, open):** `PluginFlowTest` (gradle-plugin, `test`
    source set, always-green) spawns real Gradle builds via TestKit that apply
    the `harmonica` plugin from a composite `includeBuild` of the repo root and
    run `harmonicaUp`/`harmonicaDown` against an embedded SQLite DB (absolute
@@ -343,7 +343,7 @@ Definition of done:
 - Postgres + MySQL suites green locally (Docker) and in CI (the `db-integration`
   service-container job, required mode).
 - Issue #196 satisfied — the migration flow is verified with and without
-  `harmonica-exposed` on the classpath (plugin-flow TestKit tests, PR #219).
+  `harmonica-exposed` on the classpath.
 
 ### Phase 5 — Issue backlog (quick wins first)
 

--- a/spec/tech-notes.md
+++ b/spec/tech-notes.md
@@ -1,21 +1,22 @@
 # Toolchain & Dependency Research
 
-Facts gathered on 2026-08-01 (test counts updated 2026-08-15). Update this
+Facts gathered on 2026-08-01 (test counts updated 2026-08-17). Update this
 file as versions change.
 
 ## Phase 0 status (implemented 2026-08-01; merged via PR #183, merge commit `69344da`)
 
 - Gradle wrapper **6.5 → 9.6.1**, Kotlin **1.4.20 → 2.3.20**.
-  `./gradlew clean build` is green on Java 25; **84 tests passed, 0 skipped**
-  (73 core, 6 gradle-plugin, 4 exposed, 1 SQLite integration-test).
+  `./gradlew clean build` is green on Java 25; **86 tests passed, 0 skipped**
+  (73 core, 8 gradle-plugin, 4 exposed, 1 SQLite integration-test).
   `./gradlew :integration-test:integrationTest` reports **2 gated tests**
   (PostgreSQL + MySQL) skipped when the databases are unavailable; required CI
   mode fails instead.
   Phase 0 baseline was 66; Phase 2 added 6 InflectionsTest cases;
   Phase 3, PR B added 4 ExposedMigrationTest cases; PR #201 added 2
   ScriptClasspathTest cases; Phase 4 added 5 H2 cases in `core` (PR #206), the
-  SQLite + gated PostgreSQL integration-test cases (PR #207), and the gated
-  MySQL integration-test case (PR #209).
+  SQLite + gated PostgreSQL integration-test cases (PR #207), the gated
+  MySQL integration-test case (PR #209), and 2 plugin-flow TestKit cases in
+  `gradle-plugin` (PR #219).
 - `jvmTarget = 1.8` is set via `kotlin.compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) }`
   + `java.sourceCompatibility/targetCompatibility = 1.8` in all four modules
   (`core`, `exposed`, `gradle-plugin`, `integration-test`). Verified by
@@ -75,6 +76,8 @@ Key references:
 | JDBC test drivers (mysql, postgresql, mssql) | **DONE** | removed (PR #184); server DB drivers move to the Phase 4 integration module. Exception: `org.xerial:sqlite-jdbc` is re-added as `testImplementation`-only in the `exposed` module (Phase 3, PR B) for embedded-DB Option-A transaction tests — nothing leaks into published artifacts. |
 | `com.gradle.plugin-publish` | **DONE** | 0.9.10 → **2.1.1**; legacy `pluginBundle` block removed (2.x moved config into `gradlePlugin`). |
 | `org.jetbrains.dokka` | **DONE** | 0.9.17 → **2.2.0**; removed the removed `outputFormat` DSL. Docs refresh is Phase 7. |
+| `gradleTestKit()` | **DONE** | `testImplementation`-only (Phase 4 item 4, PR #219); runs `harmonicaUp`/`harmonicaDown` in nested real Gradle builds. |
+| `org.xerial:sqlite-jdbc` | **DONE** | 3.45.3.0, `testImplementation`-only (Phase 4 item 4, PR #219); lets the plugin-flow tests assert SQLite state after the TestKit runs. |
 
 ### integration-test (Phase 4, PR #207)
 


### PR DESCRIPTION
## What

Phase 4 item 4: verify the migration flow end-to-end with Gradle TestKit, **with and without** `harmonica-exposed` on the script classpath (issue #196).

## Changes

- **`PluginFlowTest`** (gradle-plugin `test` source set, always-green): spawns real Gradle builds via TestKit that apply the `harmonica` plugin from a composite `includeBuild` of the repo root and run `harmonicaUp`/`harmonicaDown` against an embedded SQLite DB (absolute path in `<projectDir>/build/`). One case adds `harmonica("com.improve_future:exposed:2.0.0")` (Exposed migration), one does not (plain JDBC migration). Assertions check `harmonica_migration` version rows + table existence via core `Connection`.
- **`AbstractTask`/`AbstractMigrationTask` path bug fix**: migration/config paths were resolved relative to the Gradle daemon JVM cwd (`Paths.get(directoryPath, ...)`), producing `FileNotFoundException` in TestKit runs. Now `resolvePath()` resolves relative paths against `project.projectDir`.
- **`core`/`exposed`**: set `group = "com.improve_future"` + `version = "2.0.0"` so the composite build substitutes the plugin's declared `com.improve_future:*` coordinates.
- **`demo/`**: commit the scratch project as the migration seed (script/ + jarmonica/ trees, no wrapper, drivers on the buildscript classpath).
- **spec/**: test counts 84 → 86 (8 gradle-plugin), Phase 4 item 4 marked done, #196 triage row updated.

## Notes

- `./gradlew build` is green: **86 tests, 0 skipped**.
- The 2 plugin-flow cases are separate from the gated PG/MySQL integration-test suite (SQLite always-green fast path).
- Pre-existing finding (NOT fixed here, out of scope): `MigrationDownTask` throws `Error` (not `Exception`) for "More then one files exist for migration …", which escapes the `catch (e: Exception)` and leaks the connection → subsequent `SQLITE_BUSY`. Worth a follow-up issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a runnable demo supporting PostgreSQL, MySQL, and SQLite configurations.
  - Added sample migrations covering common column types, defaults, constraints, indexes, foreign keys, and rollback operations.
  - Added migration examples for both plain SQL and Exposed-based workflows.
  - Updated project release coordinates to version 2.0.0.

- **Bug Fixes**
  - Improved handling of absolute and relative migration and configuration paths.

- **Tests**
  - Added end-to-end verification for applying and rolling back migrations with and without Exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->