### PR TITLE
docs: reconcile spec after Phase 4 completion (plan-review)

### DIFF
--- a/spec/issues-triage.md
+++ b/spec/issues-triage.md
@@ -1,6 +1,6 @@
 # GitHub Issue Triage
 
-Snapshot of **open** issues on 2026-08-15 (**28 open** total). Grouped by
+Snapshot of **open** issues on 2026-08-28 (**29 open** total). Grouped by
 urgency/size. Many are already fixed (or fixable) by the toolchain/dependency
 upgrade in Phase 0/2.
 
@@ -12,7 +12,9 @@ upgrade in Phase 0/2.
 
 **Resolved and closed by Phase 0/2:** #167 (jcenter removed, CI rewritten,
 PR #183), #165 (LICENSE already MIT; README badge URLs fixed, PR #181), #140
-(kotlin-pluralizer removed, internal `singularize()`, PR #187).
+(kotlin-pluralizer removed, internal `singularize()`, PR #187). **Closed
+2026-08-28:** #182 (JitPack badge renders correctly, closed as completed —
+removed from the SMALL table).
 
 **Closed / superseded (were listed as URGENT, now resolved on `develop`):**
 the build-failure issues #159 (Win10 openjdk 15), #158 (Win/Linux openjdk 16),
@@ -27,7 +29,8 @@ superseded by Phase 0.
 | --- | --- | --- |
 | 189 | `isSubtypeOf` in scanner swallows all `Throwable` | Narrow to recoverable exceptions to match `loadClass` (PR #188); small fix in `JarmonicaTaskMain`. |
 | 196 | Real-DB tests must cover both configs: with and without Exposed | Phase 4 item 4 (plugin-flow TestKit tests). The `integration-test` module landed (PR #207) with SQLite + gated PostgreSQL smoke tests, plus a gated MySQL smoke test (PR #209); the with/without-`harmonica-exposed` migration-flow verification shipped as the plugin-flow TestKit tests (PR #219) — flow verified, GitHub issue still open pending closure. |
-| 182 | README JitPack badge shows nothing | Fix JitPack badge so it renders (README badge URLs fixed in PR #181, but this badge still broken). |
+| 220 | `harmonicaUp` fails when the SQLite DB parent directory does not exist | **Still open.** Reported in PR #219; the fix there only creates the parent dir in the TestKit project to make the test deterministic — the plugin itself still does not create the SQLite DB parent directory, so a real project pointing SQLite at e.g. `build/db/harmonica.db` hits the error today (fresh-checkout CI exposed it). Quick win for Phase 5: create the parent dir (and/or the DB file) in `harmonicaUp`/`harmonicaDown` before connecting (option 1 in the issue), then add a regression test. |
+| 222 | integration test outputs some warnings | **New (2026-08-28).** CI logs several compile/test warnings: deprecated `Project.task(name, ...)` in `gradle-plugin/build.gradle.kts:66,71`, a `MigrationDsl` DSL-marker-on-function no-op warning (`AbstractMigration.kt:40`, KT-81567), unchecked casts in `JarmonicaTaskMain`, and the `kotlin-compiler-embeddable` artifact-on-build-classpath warning. Low priority cleanup during Phase 5; the `kotlin-compiler-embeddable` warning is the one the maintainer has seen most (matches the local `integrationTest` output). |
 | 26 | Consolidate the migration file name between harmonica and jarmonica | Pick one naming convention; update both tasks + tests. |
 | 47 | Use prepared statement | Escape/`PreparedStatement` for default values (esp. varchar with quotes). |
 | 138 | Is there a need to make AbstractColumn internal? | Open up custom-column extension points (make `AbstractColumn`/`ColumnBuilder` public, document custom column pattern). |

--- a/spec/plan.md
+++ b/spec/plan.md
@@ -365,12 +365,17 @@ Full triage: [issues-triage.md]. Order:
    pluralizer PR #187); #158, #159 already closed (verified; not tracked here).
 2. Small: #26 (migration file naming), #47 (prepared statements), #138 (custom
    columns), #141 (more column types), #145 (alter column), #139 (FK options),
-   #69 (query execution API), #4 (created_at/updated_at), #182 (JitPack badge),
-   #189 (scanner `isSubtypeOf` swallows all `Throwable`).
+   #69 (query execution API), #4 (created_at/updated_at), #189 (scanner
+   `isSubtypeOf` swallows all `Throwable`).
    #91 (Exposed) is **closed** — the bridge shipped in Phase 3 (PRs #197-#199).
+   Also added in Phase 4/5: #220 (SQLite DB parent directory not created),
+   #222 (integration-test warnings) — both quick wins.
 3. Medium: #7 (closed connection), #85 (SQLite defaults), #67 (timestamp
    default), #80 (Exposed version), #71 (seeding), #97 (JavaExec task tests),
-   #155 (programmatic migration docs).
+   #155 (programmatic migration docs). Also #215 (Exposed 0.61.0 → 1.x bridge
+   rewrite): Exposed 1.x moved the JDBC API out of `org.jetbrains.exposed.sql`,
+   which breaks `harmonica-exposed` (`:exposed:compileKotlin` fails); plan the
+   bridge update when scheduling this — see §6.
 4. Large/strategic (separate designs/PRs): #1 (Maven Central), #125 (multiple
    DBs), #121 (dry run), #148 (Maven support — see `feature/maven-plugin`
    branch), #147 (Java support), #105 (adapter plugin API), #107 (SQL Server
@@ -435,7 +440,7 @@ Resolved (2026-08-01):
   catches `Throwable` — issue #189 (Phase 2, PRs #185/#188).
 - Kotlin `jvm` plugin bump 2.3.20 → 2.4.10 (PR #193): **declined** — no
   functional need; stay on 2.3.20. PR #193 is still open (dependabot) as of
-  2026-08-15; revisit before the next phase.
+  2026-08-28 — revisit/close before starting Phase 5.
 - Dependabot batch 2026-08-15 (PRs #210-#216): wrapper 9.7.0 (#211), JUnit
   6.1.3 (#210/#214), postgresql 42.7.13 (#213), H2 2.4.240 (#212),
   mysql-connector-j 26.7.0 (#216) — **merged 2026-08-16**; spec pins in
@@ -443,7 +448,7 @@ Resolved (2026-08-01):
   moved the JDBC API out of `org.jetbrains.exposed.sql`, breaking the
   `harmonica-exposed` bridge (`:exposed:compileKotlin` fails: unresolved
   `sql`/`Database`/`Transaction`). Deferred — a bridge rewrite is its own piece
-  of work; #215 stays open (see Phase 5).
+  of work; #215 stays open (tracked in Phase 5, Medium).
 
 Still open:
 


### PR DESCRIPTION
## Summary

Phase 4 is complete — all five items have merged, the last being item 2 (the
`harmonica_test` port, PR #221, merged into develop @ `32cab34`). This PR
reconciles the spec planning docs with reality per the `plan-review` workflow.

## Changes

**`spec/issues-triage.md`**
- Re-snapshot the header: **2026-08-15 (28) → 2026-08-28 (29 open)**.
- Add **#220** (`harmonicaUp` fails when the SQLite DB parent directory does
  not exist) to the SMALL quick-wins table — still open; PR #219's fix only
  creates the dir in the TestKit project, the plugin still does not.
- Add **#222** (integration-test outputs warnings) to SMALL.
- Remove **#182** (JitPack badge) — closed 2026-08-28 as completed.
- Refresh the **#196** note (work shipped via PR #219, issue open pending closure).

**`spec/plan.md`**
- Drop the now-closed #182 from the Phase 5 small-items list.
- Add #220/#222 as Phase 5 quick wins.
- Add **#215** (Exposed 0.61 → 1.x bridge rewrite) as a Phase 5 Medium item,
  fixing the dangling `(see Phase 5)` pointer in §6.
- Update the PR #193 (kotlin jvm 2.4.10) §6 note to "revisit/close before
  starting Phase 5."

## Ground truth (verified)

- `./gradlew build` on develop: **86 tests, 0 skipped** (73 core + 8 plugin +
  4 exposed + 1 SQLite integration-test).
- Versions unchanged: Gradle 9.7.0, Kotlin 2.3.20, JUnit 6.1.3.
- 2 open dependabot PRs: #215 (exposed 1.4.0, blocked — bridge rewrite is now
  a tracked Phase 5 Medium item), #193 (kotlin 2.4.10, declined).
- Spec-review agent ran: no BLOCKERs; the one WARNING (dangling #215 `Phase 5`
  ref) is fixed in this PR.

Docs-only change; no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated issue-triage records through August 28, 2026.
  - Removed the resolved JitPack badge issue from active tracking.
  - Added status and remediation details for the SQLite directory issue.
  - Documented new integration-test warnings and the Exposed 1.x migration work.
  - Refined Phase 5 backlog priorities and decision notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->