### PR TITLE
docs: encode PR-first workflow in agent control files

### DIFF
--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -1,0 +1,32 @@
+---
+description: Prepare the current branch for review and open a PR against develop. Runs the applicable review subagents, fixes BLOCKERs, then creates the PR with the repo's standard title/body. Pass an optional title as $ARGUMENTS to override the default.
+agent: general
+---
+
+Prepare the current branch and open a PR against `develop` for the Harmonica
+repo, following the PR-first workflow. Do not merge anything.
+
+1. **Confirm the tree and branch**: `git status` must be clean and the current
+   branch must not be `develop`. Fetch (`git fetch origin`) and verify the
+   branch was cut from the current `origin/develop`, not from a sibling
+   unmerged branch.
+2. **Diff scope**: `git diff origin/develop...HEAD --stat` should contain only
+   the intended files. Flag unexpected files to the user before proceeding.
+3. **Run the applicable review subagents** against the branch diff and fix any
+   BLOCKERs:
+   - `build-review` when build files / dependencies / CI changed
+     (any `build.gradle.kts`, `settings.gradle.kts`, `gradle/`, `.github/`).
+   - `exposed-review` when core connection / Exposed-optionality changed
+     (core `Connection.kt` / `PluginConfig.kt`, harmonica-exposed bridge).
+   - `spec-review` when anything under `spec/` changed.
+4. **Verify the build** (when code changed, not docs-only): run `bin/gw
+   build` (or `bin/gw test`) and record the pass + test count. Fix any red
+   build before opening the PR.
+5. **Push the branch** if not already pushed.
+6. **Create the PR** against base `origin/develop` with `gh pr create`:
+   - Title (or use `$ARGUMENTS`/`$1` if given): `Fix/Add/Refactor <subject>
+     (issue #N)` when tied to an issue, else a short descriptive title.
+   - Body with sections: **Changes**, **Verification** (build result + test
+     counts), **Residual** (anything intentionally left, e.g. issues noted as
+     closable).
+7. Return the PR URL from `gh pr view`.

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -8,22 +8,30 @@ repo, following the PR-first workflow. Do not merge anything.
 
 1. **Confirm the tree and branch**: `git status` must be clean and the current
    branch must not be `develop`. Fetch (`git fetch origin`) and verify the
-   branch was cut from the current `origin/develop`, not from a sibling
-   unmerged branch.
+   branch is not stacked on a sibling feature branch: (a)
+   `git merge-base --is-ancestor origin/develop HEAD` must succeed (develop is
+   an ancestor of HEAD), and (b) `git log --oneline origin/develop..HEAD`
+   lists only this PR's commits, none from another unmerged branch.
 2. **Diff scope**: `git diff origin/develop...HEAD --stat` should contain only
    the intended files. Flag unexpected files to the user before proceeding.
 3. **Run the applicable review subagents** against the branch diff and fix any
    BLOCKERs:
    - `build-review` when build files / dependencies / CI changed
-     (any `build.gradle.kts`, `settings.gradle.kts`, `gradle/`, `.github/`).
+     (any `build.gradle.kts`, `settings.gradle.kts`, `gradle/`,
+     `gradle.properties`, `.github/`).
    - `exposed-review` when core connection / Exposed-optionality changed
      (core `Connection.kt` / `PluginConfig.kt`, harmonica-exposed bridge).
    - `spec-review` when anything under `spec/` changed.
-4. **Verify the build** (when code changed, not docs-only): run `bin/gw
-   build` (or `bin/gw test`) and record the pass + test count. Fix any red
-   build before opening the PR.
-5. **Push the branch** if not already pushed.
-6. **Create the PR** against base `origin/develop` with `gh pr create`:
+4. **Verify the build** for any non-documentation change that can affect the
+   build — source, build files (`build.gradle.kts`, `settings.gradle.kts`,
+   `gradle/`, `gradle.properties`), or CI (`.github/`): run `bin/gw build`
+   (or `bin/gw test`) and record the pass + test count. Fix any red build
+   before opening the PR.
+5. **Commit and push the branch** — only when the user explicitly asked to
+   open a PR. If uncommitted changes exist that are not part of this PR, stop
+   and ask before committing.
+6. **Create the PR** against base `develop` with `gh pr create --base
+   develop`:
    - Title (or use `$ARGUMENTS`/`$1` if given): `Fix/Add/Refactor <subject>
      (issue #N)` when tied to an issue, else a short descriptive title.
    - Body with sections: **Changes**, **Verification** (build result + test

--- a/.opencode/commands/review-specs.md
+++ b/.opencode/commands/review-specs.md
@@ -1,5 +1,5 @@
 ---
-description: Reconcile the spec/ planning docs (plan.md, tech-notes.md, issues-triage.md) with the actual repo and apply updates. Wrapper for the plan-review skill.
+description: Reconcile the spec/ planning docs (plan.md, tech-notes.md, issues-triage.md) with the actual repo, land the reconcile as a docs PR against develop, and report closable issues. Wrapper for the plan-review skill.
 agent: general
 ---
 
@@ -7,6 +7,8 @@ Run the `plan-review` skill: gather ground truth (`git log` on `origin/develop`,
 `gh issue`/`gh pr` lists, dependency versions from the build files,
 `./gradlew test` for the authoritative test count), diff `spec/plan.md`,
 `spec/tech-notes.md`, and `spec/issues-triage.md` against it, apply the
-updates to `spec/` (never commit), then delegate a final verification pass to
-the `spec-review` agent. Report what changed and which GitHub issues the user
+updates to `spec/`, delegate a final verification pass to the `spec-review`
+agent, then commit on a `docs/...` branch cut from `origin/develop` and open a
+small PR against `develop` (never a direct push). Do not close GitHub issues
+yourself. Report what changed, the PR URL, and which GitHub issues the user
 should close.

--- a/.opencode/commands/review-specs.md
+++ b/.opencode/commands/review-specs.md
@@ -7,8 +7,10 @@ Run the `plan-review` skill: gather ground truth (`git log` on `origin/develop`,
 `gh issue`/`gh pr` lists, dependency versions from the build files,
 `./gradlew test` for the authoritative test count), diff `spec/plan.md`,
 `spec/tech-notes.md`, and `spec/issues-triage.md` against it, apply the
-updates to `spec/`, delegate a final verification pass to the `spec-review`
-agent, then commit on a `docs/...` branch cut from `origin/develop` and open a
+updates to `spec/`, and delegate a final verification pass to the `spec-review`
+agent. Commit and open the docs PR only when the user explicitly asked for the
+reconcile to land as a PR — otherwise present the edits and ask first. When
+authorized: commit on a `docs/...` branch cut from `origin/develop` and open a
 small PR against `develop` (never a direct push). Do not close GitHub issues
 yourself. Report what changed, the PR URL, and which GitHub issues the user
 should close.

--- a/.opencode/skills/harmonica-dev/SKILL.md
+++ b/.opencode/skills/harmonica-dev/SKILL.md
@@ -23,6 +23,8 @@ change.
 - `./gradlew build` works on this machine (Gradle 9.7.0 + Kotlin 2.3.20 on
   OpenJDK 25). A red build is a real bug — fix it, don't defer.
 - One change per PR against `develop`.
+- Never push directly to `develop` — docs/spec and `.opencode/**` changes go
+  through the same small-PR flow as code.
 - Never commit unless explicitly asked.
 
 ## Conventions
@@ -37,12 +39,19 @@ change.
 
 ## Workflow
 
-- Cut a phase/feature branch from `develop`, do the work, open a small PR.
+- Cut a phase/feature branch from the **current `origin/develop`** (fetch
+  first). Never cut from a sibling unmerged feature branch — it contaminates
+  the PR diff.
+- Do the work, then open a small PR. When integrating `develop` into the PR
+  branch, prefer `git merge` over rebase; never `git pull --rebase` a branch
+  that already contains merge commits, and never amend or force-push commits
+  that exist on the remote.
 - After finishing a phase, update the relevant `spec/` doc (plan phase status,
   DoD, open decisions) as part of the same PR.
 - After a phase PR or milestone merges, run the `plan-review` skill to
   reconcile `spec/plan.md`, `spec/tech-notes.md`, and `spec/issues-triage.md`
-  with reality (git log, issues/PRs, versions, test counts).
+  with reality (git log, issues/PRs, versions, test counts) — the reconcile
+  itself lands as a docs PR, never a direct push.
 - Use the review subagents (`spec-review`, `build-review`, `exposed-review`)
   to validate spec-adjacent work before opening a PR.
 

--- a/.opencode/skills/plan-review/SKILL.md
+++ b/.opencode/skills/plan-review/SKILL.md
@@ -70,6 +70,8 @@ Cross-check the three docs against each other — no contradictions.
 
 ### 5. Open a PR
 
+- Commit, push, and open the PR only when the user has explicitly asked for
+  the reconcile to land as a PR; otherwise present the edits and ask first.
 - Commit the spec changes on a `docs/...` branch cut from the current
   `origin/develop` (fetch first; never cut from a sibling unmerged branch).
 - Push it and open a small PR against `develop` titled around what the

--- a/.opencode/skills/plan-review/SKILL.md
+++ b/.opencode/skills/plan-review/SKILL.md
@@ -7,7 +7,8 @@ description: Use when reviewing the Harmonica restart plan against reality — a
 
 The `spec/` planning docs are the source of truth and go stale every time a
 phase PR merges. This workflow reconciles them with reality: gather ground
-truth, diff the docs, apply updates, verify. **Edit spec/ only. Never commit.**
+truth, diff the docs, apply updates, verify. **Edit spec/ only; every change
+goes through a small PR against `develop`, never a direct push.**
 
 ## When to run
 
@@ -67,8 +68,17 @@ Cross-check the three docs against each other — no contradictions.
 - Delegate a final pass to the `spec-review` agent (read-only) against the
   updated docs. Fix any BLOCKER/WARNING findings it reports.
 
-### 5. Report
+### 5. Open a PR
 
-Summarize: what changed in each doc, the authoritative test count, and a list
-of GitHub issues the user should close (with the PR that resolves each). Leave
-the changes uncommitted for the user to review.
+- Commit the spec changes on a `docs/...` branch cut from the current
+  `origin/develop` (fetch first; never cut from a sibling unmerged branch).
+- Push it and open a small PR against `develop` titled around what the
+  reconcile covers.
+- Do not close GitHub issues yourself — that remains a user decision; list in
+  the PR body the issues this reconcile marks as resolved, with the PR that
+  resolves each.
+
+### 6. Report
+
+Summarize: what changed in each doc, the PR URL, the authoritative test count,
+and a list of GitHub issues the user should close.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ and is being restarted. See `spec/plan.md` for the master plan.
 - The repo is on **Gradle wrapper 9.7.0** and **Kotlin 2.3.20** (Phase 0, merged
   via PR #183; wrapper bumped via PR #211). `./gradlew build` works on this machine.
 - **Small changes per PR** against `develop`.
+- **Never push directly to `develop`.** Every change — code *and* docs/spec —
+  goes through a small PR against `develop`.
 - **Never commit** unless explicitly asked. Stage only intended files.
 
 ## Layout
@@ -40,3 +42,15 @@ and is being restarted. See `spec/plan.md` for the master plan.
 - Keep `core` free of any Exposed import. See `spec/exposed-integration.md`.
 - When editing opencode config (`opencode.json`, `.opencode/**`), consult the
   `customize-opencode` skill and the schema at https://opencode.ai/config.json.
+
+## Git workflow
+
+- Cut feature branches from the current `origin/develop` (fetch first). Never
+  cut from a sibling unmerged feature branch — it contaminates the PR diff.
+- When integrating `develop` into a PR branch, prefer `git merge` over rebase.
+  Never `git pull --rebase` a branch that already contains merge commits, and
+  never amend or force-push commits that exist on the remote.
+- Before opening a PR, run the applicable review subagents against the branch
+  diff (spec-review for `spec/`, build-review for build/dependency/CI changes,
+  exposed-review for core connection / Exposed work) and fix any BLOCKERs. The
+  `/pr` command encodes this flow.


### PR DESCRIPTION
## Changes
Concrete rules extracted from lessons learned on Phase 5 quick wins (PRs #224-#227):

- **AGENTS.md**: new `Git workflow` section — never push to `develop` directly (docs/spec included); cut feature branches from current `origin/develop`, never from sibling unmerged branches; prefer `git merge` over rebase, no `git pull --rebase` on merge-containing branches, no amend/force-push on remote commits; run the applicable review subagents before opening a PR.
- **harmonica-dev** skill: hard constraints + workflow mirror the same rules.
- **plan-review** skill: reconcile now lands as a docs PR (step 5 opens a `docs/...` PR) instead of `Never commit / leave uncommitted`.
- **new `/pr` command**: prepares the branch (diff-scope check), runs applicable review agents, verifies build, then creates the PR with the standard title/body.
- **review-specs command**: realigned to the PR-based reconcile flow.

## Verification
Docs-only change; no build needed. Noted in the PR body that GitHub issue closures remain a user decision.

## Residual
- The `.opencode/.gitignore` node entries (package.json/package-lock.json/bun.lock/node_modules) are now stale after removing the unused `@opencode-ai/plugin` dependency; left in place defensively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/pr` workflow that validates changes, runs reviews, verifies builds, pushes the branch, and opens a pull request with a standardized format.
  * Updated specification review workflows to commit changes on documentation branches and open pull requests against `develop`.

* **Documentation**
  * Clarified branch management, review, merge, and pull request practices.
  * Added guidance requiring documentation and specification changes to follow the same pull request process as code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->