### PR TITLE
build: bump project version 2.0.0 -> 3.0.0

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.improve_future"
-version = "2.0.0"
+version = "3.0.0"
 
 repositories {
     mavenCentral()

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -10,12 +10,12 @@ buildscript {
 }
 
 group = "com.improve_future"
-version = "2.0.0"
+version = "3.0.0"
 
 plugins {
     kotlin("jvm") version "2.3.20"
-    id("harmonica") version "2.0.0"
-    id("jarmonica") version "2.0.0"
+    id("harmonica") version "3.0.0"
+    id("jarmonica") version "3.0.0"
 }
 
 extra["directoryPath"] = "src/main/kotlin/com/improve_future/harmonica/demo/script"
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.improve_future:gradle-plugin:2.0.0")
-    harmonica("com.improve_future:exposed:2.0.0")
+    implementation("com.improve_future:gradle-plugin:3.0.0")
+    harmonica("com.improve_future:exposed:3.0.0")
     implementation("org.xerial:sqlite-jdbc:3.45.3.0")
 }

--- a/document/src/main/kotlin/com/improve_future/harmonica/document/view/JarmonicaView.kt
+++ b/document/src/main/kotlin/com/improve_future/harmonica/document/view/JarmonicaView.kt
@@ -55,7 +55,7 @@ object JarmonicaView : AbstractView() {
                                         +"""
 buildscript {
     ext.kotlin_version = '1.4.20'
-    ext.harmonica_version = '2.0.0'
+    ext.harmonica_version = '3.0.0'
 
     repositories {
         jcenter()

--- a/exposed/build.gradle.kts
+++ b/exposed/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.improve_future"
-version = "2.0.0"
+version = "3.0.0"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.improve_future"
-version = "2.0.0"
+version = "3.0.0"
 
 repositories {
     mavenCentral()

--- a/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/improve_future/harmonica/plugin/PluginFlowTest.kt
@@ -78,14 +78,14 @@ class PluginFlowTest {
             appendLine("    }")
             appendLine("}")
             appendLine("plugins {")
-            appendLine("    id(\"harmonica\") version \"2.0.0\"")
+            appendLine("    id(\"harmonica\") version \"3.0.0\"")
             appendLine("}")
             appendLine("repositories {")
             appendLine("    mavenCentral()")
             appendLine("}")
             if (withExposed) {
                 appendLine("dependencies {")
-                appendLine("    harmonica(\"com.improve_future:exposed:2.0.0\")")
+                appendLine("    harmonica(\"com.improve_future:exposed:3.0.0\")")
                 appendLine("}")
             }
         }.toString()

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":exposed"))
 
-    testImplementation("com.improve_future:harmonica-demo:2.0.0")
+    testImplementation("com.improve_future:harmonica-demo:3.0.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.3")
@@ -26,7 +26,7 @@ dependencies {
 
     add("integrationTestImplementation", project(":core"))
     add("integrationTestImplementation", project(":exposed"))
-    add("integrationTestImplementation", "com.improve_future:harmonica-demo:2.0.0")
+    add("integrationTestImplementation", "com.improve_future:harmonica-demo:3.0.0")
     add("integrationTestImplementation", sourceSets["test"].output)
     add("integrationTestImplementation", "org.jetbrains.kotlin:kotlin-test:${property("kotlin_version")}")
     add("integrationTestImplementation", "org.jetbrains.kotlin:kotlin-test-junit5:${property("kotlin_version")}")

--- a/spec/README.md
+++ b/spec/README.md
@@ -67,7 +67,7 @@ plan to restart and modernize the project.
   `harmonica_test` port is DONE (PR #221). The `demo/` module (seed for the
   plugin-flow demo and the ported 4-migration fixtures) is wired into the root
   build as a composite `includeBuild`, so `integration-test` reuses its
-  migration classes via `com.improve_future:harmonica-demo:2.0.0`.
+  migration classes via `com.improve_future:harmonica-demo:3.0.0`.
 - **`develop` is 139 commits ahead of `master`** — Phase 4 (real-DB tests) must
   pass before `master` advances. See the risk register in [`plan.md`](plan.md).
 


### PR DESCRIPTION
## Changes
Release prep (Phase 6) — bump all module versions `2.0.0` → `3.0.0`:

- `core`, `exposed`, `gradle-plugin` build scripts
- `demo/` → own `version` + declared harmonica/exposed/gradle-plugin coordinates and plugin ids (composite `includeBuild` substitution must match the new module versions)
- `integration-test` → `com.improve_future:harmonica-demo:3.0.0`
- `PluginFlowTest` → generated TestKit build script (`id("harmonica") version "3.0.0"`, `harmonica("...:exposed:3.0.0")`)
- `document` site source → `harmonica_version` sample string
- `spec/README.md` → harmonica-demo coordinate bumped to stay the source of truth

## Verification
- `bin/gw build` ✅ (2m25s; PluginFlowTest + SQLite always-green tests pass)
- build-review subagent: CLEAR
- spec-review subagent: CLEAR
- Repo-wide grep confirms zero remaining `2.0.0` literals in build sources; JVM 8 `jvmTarget` untouched.

## Note (follow-ups, not this PR)
- `spec/exposed-integration.md:229` and `spec/plan.md:317/322` still show 2.0.0 as pre-existing/historical staleness → plan-review sweep later.
- Doc-site `document/` content is outdated; system stays, content refresh is a separate step.